### PR TITLE
feat: make all test buttons disabled if wallet is not connected

### DIFF
--- a/src/modules/tests/tests/batch/batch.vue
+++ b/src/modules/tests/tests/batch/batch.vue
@@ -4,7 +4,10 @@
       Batch operation will send a transfer of 1 tez to yourself, and increment
       the counter contract storage by 1.
     </p>
-    <Button @click="sendBatchOperation()" :disabled="sending">
+    <Button
+      @click="sendBatchOperation()"
+      :disabled="sending || !walletStore.getAddress"
+    >
       <Group v-if="!sending" class="size-6" />
       <LoaderCircle v-else class="size-5 animate-spin" />
       <p>Send Batch Operation</p>
@@ -18,8 +21,10 @@ import Button from "@/components/ui/button/Button.vue";
 import { onMounted, ref } from "vue";
 import { Group, LoaderCircle } from "lucide-vue-next";
 import { sendBatch } from "@/modules/tests/tests/batch/batch";
+import { useWalletStore } from "@/stores/walletStore";
 
 const diagramStore = useDiagramStore();
+const walletStore = useWalletStore();
 
 onMounted(() => {
   diagramStore.setTestDiagram("batch");

--- a/src/modules/tests/tests/counter/counter-contract.vue
+++ b/src/modules/tests/tests/counter/counter-contract.vue
@@ -1,22 +1,30 @@
 <template>
   <div class="flex items-center w-full justify-center gap-4">
-    <Button @click="decrementCounter()">
+    <Button @click="decrementCounter()" :disabled="!walletConnected">
       <Minus class="size-6" />
       <p class="sr-only">Decrement</p>
     </Button>
     <div class="flex flex-col items-center gap-2">
-      <Button variant="ghost" @click="getStorageValue()">
+      <Button
+        variant="ghost"
+        @click="getStorageValue()"
+        :disabled="!walletConnected"
+      >
         <RefreshCw class="size-4" />
         <p class="sr-only">Get Storage Value</p>
       </Button>
       <p class="text-5xl font-bold">{{ storageValue ?? "..." }}</p>
       <p class="text-sm text-muted-foreground">Storage Value</p>
-      <Button variant="ghost" @click="resetCounter()">
+      <Button
+        variant="ghost"
+        @click="resetCounter()"
+        :disabled="!walletConnected"
+      >
         <Trash class="size-4" />
         <p class="sr-only">Reset</p>
       </Button>
     </div>
-    <Button @click="incrementCounter()">
+    <Button @click="incrementCounter()" :disabled="!walletConnected">
       <Plus class="size-6" />
       <p class="sr-only">Increment</p>
     </Button>
@@ -32,10 +40,14 @@ import {
   reset,
   getContractStorage,
 } from "@/modules/tests/tests/counter/counter-contract";
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { Minus, Plus, RefreshCw, Trash } from "lucide-vue-next";
+import { useWalletStore } from "@/stores/walletStore";
 
 const diagramStore = useDiagramStore();
+const walletStore = useWalletStore();
+
+const walletConnected = computed(() => !!walletStore.getAddress);
 
 const storageValue = ref<number>();
 

--- a/src/modules/tests/tests/estimate-fees/estimate-fees.vue
+++ b/src/modules/tests/tests/estimate-fees/estimate-fees.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="w-full flex justify-center">
-    <Button @click="estimate()" :disabled="sending" class="w-32">
+    <Button
+      @click="estimate()"
+      :disabled="sending || !walletStore.getAddress"
+      class="w-32"
+    >
       <Loader2 v-if="sending" class="w-4 h-4 mr-2 animate-spin" />
       <p v-else>Estimate Fees</p>
     </Button>
@@ -13,9 +17,11 @@ import { ref, onMounted } from "vue";
 import Button from "@/components/ui/button/Button.vue";
 import { Loader2 } from "lucide-vue-next";
 import { estimateFees } from "@/modules/tests/tests/estimate-fees/estimate-fees";
+import { useWalletStore } from "@/stores/walletStore";
 
 const sending = ref<boolean>(false);
 const diagramStore = useDiagramStore();
+const walletStore = useWalletStore();
 
 onMounted(() => {
   diagramStore.setTestDiagram("estimate-fees");

--- a/src/modules/tests/tests/increase-paid-storage/increase-paid-storage.vue
+++ b/src/modules/tests/tests/increase-paid-storage/increase-paid-storage.vue
@@ -19,7 +19,11 @@
         </NumberFieldContent>
       </NumberField>
     </div>
-    <Button @click="increase()" :disabled="processing" class="w-32">
+    <Button
+      @click="increase()"
+      :disabled="processing || !walletStore.getAddress"
+      class="w-32"
+    >
       <Loader2 v-if="processing" class="w-4 h-4 mr-2 animate-spin" />
       <p v-else>Increase Storage</p>
     </Button>
@@ -41,14 +45,25 @@ import {
 } from "@/components/ui/number-field";
 import { Loader2 } from "lucide-vue-next";
 import { increaseStorage } from "@/modules/tests/tests/increase-paid-storage/increase-paid-storage";
-// Seoulnet
-const contractAddress = ref<string>("KT1RLWdB5zJcN7RVqu5MRWp3gvkMUGEpuc1d");
+import { useWalletStore } from "@/stores/walletStore";
+import type { ContractConfig } from "@/types/contract";
+import contracts from "@/contracts/contract-config.json";
+
+const contractAddress = ref<string>();
 const bytes = ref<number>(1);
 const processing = ref<boolean>(false);
 const diagramStore = useDiagramStore();
+const walletStore = useWalletStore();
 
 onMounted(() => {
   diagramStore.setTestDiagram("transfer");
+
+  const CONTRACT_ADDRESS =
+    (contracts as ContractConfig[]).find(
+      (contract: ContractConfig) => contract.contractName === "counter",
+    )?.address ?? "";
+
+  contractAddress.value = CONTRACT_ADDRESS;
 });
 
 const increase = async () => {

--- a/src/modules/tests/tests/staking/staking.vue
+++ b/src/modules/tests/tests/staking/staking.vue
@@ -47,7 +47,7 @@
               variant="ghost"
               size="icon"
               @click="getStakedBalance"
-              :disabled="loadingBalance"
+              :disabled="loadingBalance || !walletConnected"
             >
               <RotateCcw class="size-4 mt-1" />
               <p class="sr-only">Refresh Staked Balance</p>
@@ -70,7 +70,8 @@
               !currentDelegate ||
               !acceptsStaking ||
               stakingLoading ||
-              anyOperationLoading
+              anyOperationLoading ||
+              !walletConnected
             "
             @click="stakeTokens"
             data-testid="stake-button"
@@ -83,7 +84,10 @@
             class="w-full"
             variant="secondary"
             :disabled="
-              !currentDelegate || unstakingLoading || anyOperationLoading
+              !currentDelegate ||
+              unstakingLoading ||
+              anyOperationLoading ||
+              !walletConnected
             "
             @click="unstakeTokens"
             data-testid="unstake-button"
@@ -97,7 +101,10 @@
         <Button
           class="w-full"
           :disabled="
-            !currentDelegate || finalizingLoading || anyOperationLoading
+            !currentDelegate ||
+            finalizingLoading ||
+            anyOperationLoading ||
+            !walletConnected
           "
           @click="finalizeUnstakeTokens"
           data-testid="finalize-button"
@@ -159,6 +166,7 @@ const anyOperationLoading = computed(() => {
 const loadingDelegateInformation = ref<boolean>(true);
 const currentDelegate = ref<string | null>();
 const acceptsStaking = ref<boolean>();
+const walletConnected = computed(() => !!walletStore.getAddress);
 
 onMounted(async () => {
   diagramStore.setTestDiagram("staking");

--- a/src/modules/tests/tests/transfer/transfer-tez.vue
+++ b/src/modules/tests/tests/transfer/transfer-tez.vue
@@ -15,7 +15,11 @@
         </NumberFieldContent>
       </NumberField>
     </div>
-    <Button @click="sendTransfer()" :disabled="sending" class="w-32">
+    <Button
+      @click="sendTransfer()"
+      :disabled="sending || !walletStore.getAddress"
+      class="w-32"
+    >
       <Loader2 v-if="sending" class="w-4 h-4 mr-2 animate-spin" />
       <p v-else>Send Transfer</p>
     </Button>


### PR DESCRIPTION
This PR disables all the test buttons and prevents interaction if the user does not have a wallet connected.

It also fixes an issue where the current delegate was not re-checked when connecting or disconnecting a wallet if you were already on the delegation test page.