### PR TITLE
feat: remove prerequisites and learning goals

### DIFF
--- a/src/modules/tests/components/test-wrapper.vue
+++ b/src/modules/tests/components/test-wrapper.vue
@@ -14,54 +14,7 @@
         </p>
       </div>
 
-      <!-- Top Section: Learning Goals, Prerequisites, Setup -->
       <div class="grid gap-4 grid-cols-1 lg:grid-cols-3 w-full">
-        <!-- Learning Goals -->
-        <Card>
-          <CardHeader>
-            <CardTitle class="flex items-center gap-2">
-              <Target class="h-5 w-5" />
-              Learning Goals
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul class="space-y-2">
-              <li
-                v-for="goal in testMetadata.learningGoals"
-                :key="goal"
-                class="flex items-start gap-2"
-              >
-                <CheckCircle
-                  class="h-4 w-4 text-green-500 mt-0.5 flex-shrink-0"
-                />
-                <span class="text-sm">{{ goal }}</span>
-              </li>
-            </ul>
-          </CardContent>
-        </Card>
-
-        <!-- Prerequisites -->
-        <Card>
-          <CardHeader>
-            <CardTitle class="flex items-center gap-2">
-              <ClipboardList class="h-5 w-5" />
-              Prerequisites
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul class="space-y-2">
-              <li
-                v-for="prereq in testMetadata.prerequisites"
-                :key="prereq"
-                class="flex items-start gap-2"
-              >
-                <Circle class="h-4 w-4 text-blue-500 mt-0.5 flex-shrink-0" />
-                <span class="text-sm">{{ prereq }}</span>
-              </li>
-            </ul>
-          </CardContent>
-        </Card>
-
         <!-- Setup -->
         <Card>
           <CardHeader>
@@ -87,6 +40,89 @@
             </ul>
           </CardContent>
         </Card>
+        <!-- Related Tests -->
+        <Card class="w-full">
+          <CardHeader>
+            <CardTitle class="flex items-center gap-2">
+              <Link class="h-5 w-5" />
+              Related Tests
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div v-if="testMetadata.relatedTests.length > 0" class="space-y-2">
+              <router-link
+                v-for="relatedTestId in testMetadata.relatedTests"
+                :key="relatedTestId"
+                :to="`/tests/${relatedTestId}`"
+                class="flex items-center gap-2 p-2 rounded-md hover:bg-muted transition-colors"
+              >
+                <ArrowRight class="h-4 w-4 text-muted-foreground" />
+                <span class="text-sm font-medium">{{
+                  getTestTitle(relatedTestId)
+                }}</span>
+              </router-link>
+            </div>
+            <p v-else class="text-sm text-muted-foreground">
+              No related tests available
+            </p>
+          </CardContent>
+        </Card>
+
+        <!-- Source Code & Documentation -->
+        <Card class="w-full">
+          <CardHeader>
+            <CardTitle class="flex items-center gap-2">
+              <Code class="h-5 w-5" />
+              Source & Documentation
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div class="space-y-3">
+              <div
+                v-if="testMetadata.sourceCode.contract"
+                class="flex items-center gap-2"
+              >
+                <FileCode class="h-4 w-4 text-muted-foreground" />
+                <a
+                  :href="testMetadata.sourceCode.contract"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-sm text-primary hover:underline"
+                >
+                  Contract Source
+                </a>
+              </div>
+              <div
+                v-if="testMetadata.sourceCode.script"
+                class="flex items-center gap-2"
+              >
+                <FileText class="h-4 w-4 text-muted-foreground" />
+                <a
+                  :href="testMetadata.sourceCode.script"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-sm text-primary hover:underline"
+                >
+                  Script Source
+                </a>
+              </div>
+              <div
+                v-if="testMetadata.sourceCode.documentation"
+                class="flex items-center gap-2"
+              >
+                <BookOpen class="h-4 w-4 text-muted-foreground" />
+                <a
+                  :href="testMetadata.sourceCode.documentation"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-sm text-primary hover:underline"
+                >
+                  Documentation
+                </a>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
       </div>
 
       <!-- Middle Section: Actual Test Content -->
@@ -94,7 +130,7 @@
         <slot />
       </div>
 
-      <!-- Bottom Section: Operational Flow, Related Tests, Sources -->
+      <!-- Bottom Section: Operational Flow -->
       <div class="border-t pt-8 space-y-6">
         <!-- Operational Flow -->
         <Card>
@@ -108,95 +144,6 @@
             <TestDiagram />
           </CardContent>
         </Card>
-
-        <div class="grid gap-6 grid-cols-1 lg:grid-cols-2 w-full">
-          <!-- Related Tests -->
-          <Card class="w-full">
-            <CardHeader>
-              <CardTitle class="flex items-center gap-2">
-                <Link class="h-5 w-5" />
-                Related Tests
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div
-                v-if="testMetadata.relatedTests.length > 0"
-                class="space-y-2"
-              >
-                <router-link
-                  v-for="relatedTestId in testMetadata.relatedTests"
-                  :key="relatedTestId"
-                  :to="`/tests/${relatedTestId}`"
-                  class="flex items-center gap-2 p-2 rounded-md hover:bg-muted transition-colors"
-                >
-                  <ArrowRight class="h-4 w-4 text-muted-foreground" />
-                  <span class="text-sm font-medium">{{
-                    getTestTitle(relatedTestId)
-                  }}</span>
-                </router-link>
-              </div>
-              <p v-else class="text-sm text-muted-foreground">
-                No related tests available
-              </p>
-            </CardContent>
-          </Card>
-
-          <!-- Source Code & Documentation -->
-          <Card class="w-full">
-            <CardHeader>
-              <CardTitle class="flex items-center gap-2">
-                <Code class="h-5 w-5" />
-                Source & Documentation
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div class="space-y-3">
-                <div
-                  v-if="testMetadata.sourceCode.contract"
-                  class="flex items-center gap-2"
-                >
-                  <FileCode class="h-4 w-4 text-muted-foreground" />
-                  <a
-                    :href="testMetadata.sourceCode.contract"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-sm text-primary hover:underline"
-                  >
-                    Contract Source
-                  </a>
-                </div>
-                <div
-                  v-if="testMetadata.sourceCode.script"
-                  class="flex items-center gap-2"
-                >
-                  <FileText class="h-4 w-4 text-muted-foreground" />
-                  <a
-                    :href="testMetadata.sourceCode.script"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-sm text-primary hover:underline"
-                  >
-                    Script Source
-                  </a>
-                </div>
-                <div
-                  v-if="testMetadata.sourceCode.documentation"
-                  class="flex items-center gap-2"
-                >
-                  <BookOpen class="h-4 w-4 text-muted-foreground" />
-                  <a
-                    :href="testMetadata.sourceCode.documentation"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-sm text-primary hover:underline"
-                  >
-                    Documentation
-                  </a>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
       </div>
     </div>
   </div>
@@ -213,10 +160,6 @@ import { useDiagramStore } from "@/stores/diagramStore";
 import { onUnmounted } from "vue";
 import {
   BookOpen,
-  Target,
-  CheckCircle,
-  ClipboardList,
-  Circle,
   Settings,
   Link,
   ArrowRight,

--- a/src/modules/tests/test.ts
+++ b/src/modules/tests/test.ts
@@ -20,8 +20,6 @@ export interface TestMetadata {
   title: string;
   description: string;
   category: string;
-  learningGoals: string[];
-  prerequisites: string[];
   setup: string[];
   relatedTests: string[];
   sourceCode: {

--- a/src/modules/tests/tests.ts
+++ b/src/modules/tests/tests.ts
@@ -7,17 +7,6 @@ export const AvailableTests: Record<string, TestMetadata> = {
     description:
       "Learn how to transfer Tez tokens between Tezos addresses using Taquito's Wallet API. This fundamental operation demonstrates the core transaction flow including fee estimation, user confirmation, and blockchain confirmation.",
     category: "Core Operations",
-    learningGoals: [
-      "Understand Tez transfer operations using the Wallet API",
-      "Understand transaction parameters (amount, destination, fees)",
-      "Learn proper error handling and transaction confirmation patterns",
-      "Practice waiting for user wallet confirmation and blockchain confirmations",
-    ],
-    prerequisites: [
-      "Basic understanding of Tezos wallet addresses and public key hashes",
-      "Familiarity with JavaScript Promises and async/await syntax",
-      "Knowledge of Tezos transaction structure and gas fees",
-    ],
     setup: [
       "Install and configure Taquito: `npm install @taquito/taquito`",
       "Set up a Tezos wallet (Temple, Kukai, or other supported wallet)",
@@ -55,18 +44,6 @@ export const AvailableTests: Record<string, TestMetadata> = {
     description:
       "Interact with a deployed counter smart contract to understand smart contract interaction patterns. Learn how to call contract methods, read storage, and handle contract operations using Taquito.",
     category: "Smart Contracts",
-    learningGoals: [
-      "Understand smart contract interaction using Taquito's methodsObject",
-      "Understand contract storage reading and state management",
-      "Practice proper error handling for contract operations",
-      "Grasp the difference between read operations (storage) and write operations (method calls)",
-      "Learn to wait for contract operation confirmations",
-    ],
-    prerequisites: [
-      "Basic understanding of smart contract concepts and Michelson (or abstracts such as Jsligo)",
-      "Knowledge of contract addresses",
-      "Basic understanding of contract storage and parameter encoding",
-    ],
     setup: [
       "Install Taquito: `npm install @taquito/taquito`",
       "Set up a Tezos wallet with sufficient Tez for gas fees",
@@ -171,18 +148,6 @@ export const AvailableTests: Record<string, TestMetadata> = {
     description:
       "Learn how to increase the paid storage allocation for smart contracts on Tezos. This operation allows you to expand a contract's storage capacity by paying additional fees.",
     category: "Smart Contracts",
-    learningGoals: [
-      "Understand Tezos storage model and paid storage concept",
-      "Learn to calculate and pay for additional storage allocation",
-      "Understand storage costs and fee calculation for storage operations",
-      "Learn to handle storage-related errors and confirmations",
-    ],
-    prerequisites: [
-      "Understanding of Tezos smart contract storage model",
-      "Knowledge of storage costs and fee structures",
-      "Familiarity with contract operations and confirmations",
-      "Understanding of contract addresses and ownership",
-    ],
     setup: [
       "Install Taquito: `npm install @taquito/taquito`",
       "Set up a Tezos wallet with sufficient Tez for storage fees",
@@ -224,16 +189,7 @@ export const AvailableTests: Record<string, TestMetadata> = {
     description:
       "Learn to estimate transaction fees, gas limits, and storage costs before executing operations.",
     category: "Core Operations",
-    learningGoals: [
-      "Understand gas limits, storage costs, and fee components",
-      "Learn to use Taquito's EstimateProvider for accurate cost calculations",
-    ],
-    prerequisites: [
-      "Basic understanding of Tezos transaction structure",
-      "Knowledge of gas fees, storage fees, and baker fees",
-      "Familiarity with operation types and their cost implications",
-      "Understanding of transaction limits and their importance",
-    ],
+
     setup: [
       "Install Taquito: `npm install @taquito/taquito`",
       "Configure Taquito with RPC endpoint",
@@ -272,19 +228,6 @@ export const AvailableTests: Record<string, TestMetadata> = {
     description:
       "Learn to delegate your baking rights to another baker or remove delegation. Delegation allows you to participate in Tezos consensus and earn rewards without running your own baker infrastructure.",
     category: "Staking & Consensus",
-    learningGoals: [
-      "Understand Tezos delegation and baking rights",
-      "Understand setting a delegate using Taquito's delegation API",
-      "Learn to remove delegation and reclaim baking rights",
-      "Practice proper error handling for delegation operations",
-    ],
-    prerequisites: [
-      "A Tezos wallet not currently registered as a baker",
-      "Understanding of Tezos Proof of Stake consensus mechanism",
-      "Knowledge of baking rights and delegation concepts",
-      "Familiarity with baker addresses and delegation relationships",
-      "Understanding of account types and delegation requirements",
-    ],
     setup: [
       "Install Taquito: `npm install @taquito/taquito`",
       "Set up a Tezos wallet with sufficient Tez",
@@ -347,16 +290,6 @@ export const AvailableTests: Record<string, TestMetadata> = {
     description:
       "Learn about staking operations including staking/unstaking tokens and finalizing unstaking operations.",
     category: "Staking & Consensus",
-    learningGoals: [
-      "Understand staking operations with proper parameter handling",
-      "Understand finalization of unstaking operations",
-      "Practice error handling for staking operations",
-    ],
-    prerequisites: [
-      "Understanding of Tezos staking and delegation concepts",
-      "A Tezos wallet delegated to a baker",
-      "A Tezos wallet with sufficient Tez for staking",
-    ],
     setup: [
       "Install Taquito: `npm install @taquito/taquito`",
       "Set up a Tezos wallet with sufficient Tez for staking",
@@ -438,17 +371,6 @@ export const AvailableTests: Record<string, TestMetadata> = {
     description:
       "Learn to batch multiple Tezos operations into a single transaction.",
     category: "Advanced Operations",
-    learningGoals: [
-      "Understand Taquito's Batch API for combining multiple operations",
-      "Learn to handle different operation types in batches",
-      "Practice proper error handling for batch operations",
-      "Understand batch confirmation and atomic execution",
-    ],
-    prerequisites: [
-      "Understanding of individual Tezos operations (transfers, contract calls)",
-      "Knowledge of gas costs and fee structures",
-      "Familiarity with operation confirmation patterns",
-    ],
     setup: [
       "Install Taquito: `npm install @taquito/taquito`",
       "Set up a Tezos wallet with sufficient Tez for batch gas fees",
@@ -497,18 +419,6 @@ export const AvailableTests: Record<string, TestMetadata> = {
     description:
       "Learn to sign data payloads using Tezos wallets and verify signatures. This includes signing Micheline expressions, packing data, and verifying signatures.",
     category: "Cryptography & Security",
-    learningGoals: [
-      "Learn to pack and sign Micheline expressions",
-      "Understand signature verification",
-      "Practice proper payload formatting and encoding",
-      "Learn to handle different payload types",
-    ],
-    prerequisites: [
-      "Understanding of cryptographic signatures and public key cryptography",
-      "Knowledge of Micheline data format and encoding",
-      "Familiarity with Tezos wallet signing capabilities",
-      "Understanding of payload packing and unpacking",
-    ],
     setup: [
       "Install Taquito: `npm install @taquito/taquito`",
       "Set up a Tezos wallet with signing capabilities",
@@ -618,17 +528,6 @@ export const AvailableTests: Record<string, TestMetadata> = {
     description:
       "Learn to set transaction limits for smart contract interactions to control gas consumption and storage costs.",
     category: "Smart Contracts",
-    learningGoals: [
-      "Understand transaction limits and their importance in Tezos",
-      "Understand setting gas limits and storage limits for contract calls",
-      "Understand the relationship between limits and operation success",
-    ],
-    prerequisites: [
-      "Understanding of Tezos gas model and storage costs",
-      "Knowledge of smart contract interaction patterns",
-      "Familiarity with fee estimation and transaction parameters",
-      "Understanding of operation failure scenarios and rollbacks",
-    ],
     setup: [
       "Install Taquito: `npm install @taquito/taquito`",
       "Set up a Tezos wallet with sufficient Tez for gas fees",
@@ -681,16 +580,7 @@ export const AvailableTests: Record<string, TestMetadata> = {
     description:
       "Learn to use the Failing Noop instruction in Tezos to deliberately fail an operation.",
     category: "Smart Contracts",
-    learningGoals: [
-      "Understand the purpose and use cases of the Failing Noop instruction",
-      "Learn how to simulate operation failures in Tezos",
-      "Recognize how Failing Noop can be used for testing error handling and rollbacks",
-    ],
-    prerequisites: [
-      "Basic understanding of Michelson and Tezos smart contracts",
-      "Familiarity with operation flows and error handling in Tezos",
-      "Knowledge of Taquito and contract interaction patterns",
-    ],
+
     setup: [
       "Install Taquito: `npm install @taquito/taquito`",
       "Set up a Tezos wallet with sufficient Tez for gas fees",


### PR DESCRIPTION
This pull request refactors the test metadata structure and updates the `test-wrapper.vue` component to simplify the test information display. The main change is the removal of the `learningGoals` and `prerequisites` fields from the test metadata and the corresponding UI sections. The component layout is also reorganized for clarity, focusing on setup, test content, and operational flow.

**Test metadata simplification:**

* Removed the `learningGoals` and `prerequisites` fields from the `TestMetadata` interface in `test.ts` and from all test definitions in `tests.ts`, streamlining the metadata to only include essential fields such as `setup`, `relatedTests`, and `sourceCode`.

**UI and component layout updates:**

* Removed the Learning Goals and Prerequisites card sections from the top of the `test-wrapper.vue` component, reflecting the metadata changes.
* Reorganized the component layout to have a clear separation: setup section at the top, test content in the middle, and operational flow at the bottom.

**Minor UI fixes:**

* Adjusted the indentation and formatting for the related tests section to improve readability.

These changes make the test metadata and UI more focused and easier to maintain.