### PR TITLE
feat: add link to tezos docs

### DIFF
--- a/src/modules/tests/components/test-wrapper.vue
+++ b/src/modules/tests/components/test-wrapper.vue
@@ -49,7 +49,7 @@
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div v-if="testMetadata.relatedTests.length > 0" class="space-y-2">
+            <div v-if="testMetadata.relatedTests.length > 0">
               <router-link
                 v-for="relatedTestId in testMetadata.relatedTests"
                 :key="relatedTestId"

--- a/src/modules/tests/components/test-wrapper.vue
+++ b/src/modules/tests/components/test-wrapper.vue
@@ -4,7 +4,7 @@
       <!-- Header Section -->
       <div class="space-y-1">
         <div class="flex items-center gap-1">
-          <BookOpen class="size-6 mt-0.5 shrink-0" />
+          <BookOpenText class="size-6 mt-0.5 shrink-0" />
           <h1 class="text-2xl font-bold tracking-tight">
             {{ testMetadata.title }}
           </h1>
@@ -79,12 +79,12 @@
           <CardContent>
             <div class="space-y-3">
               <div
-                v-if="testMetadata.sourceCode.contract"
+                v-if="testMetadata.documentation.contract"
                 class="flex items-center gap-2"
               >
                 <FileCode class="h-4 w-4 text-muted-foreground" />
                 <a
-                  :href="testMetadata.sourceCode.contract"
+                  :href="testMetadata.documentation.contract"
                   target="_blank"
                   rel="noopener noreferrer"
                   class="text-sm text-primary hover:underline"
@@ -93,12 +93,12 @@
                 </a>
               </div>
               <div
-                v-if="testMetadata.sourceCode.script"
+                v-if="testMetadata.documentation.script"
                 class="flex items-center gap-2"
               >
                 <FileText class="h-4 w-4 text-muted-foreground" />
                 <a
-                  :href="testMetadata.sourceCode.script"
+                  :href="testMetadata.documentation.script"
                   target="_blank"
                   rel="noopener noreferrer"
                   class="text-sm text-primary hover:underline"
@@ -107,17 +107,31 @@
                 </a>
               </div>
               <div
-                v-if="testMetadata.sourceCode.documentation"
+                v-if="testMetadata.documentation.taqutioDocumentation"
                 class="flex items-center gap-2"
               >
-                <BookOpen class="h-4 w-4 text-muted-foreground" />
+                <BookOpenText class="h-4 w-4 text-muted-foreground" />
                 <a
-                  :href="testMetadata.sourceCode.documentation"
+                  :href="testMetadata.documentation.taqutioDocumentation"
                   target="_blank"
                   rel="noopener noreferrer"
                   class="text-sm text-primary hover:underline"
                 >
-                  Documentation
+                  Taquito Documentation
+                </a>
+              </div>
+              <div
+                v-if="testMetadata.documentation.tezosDocumentation"
+                class="flex items-center gap-2"
+              >
+                <BookOpenText class="h-4 w-4 text-muted-foreground" />
+                <a
+                  :href="testMetadata.documentation.tezosDocumentation"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-sm text-primary hover:underline"
+                >
+                  Tezos Documentation
                 </a>
               </div>
             </div>
@@ -159,7 +173,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useDiagramStore } from "@/stores/diagramStore";
 import { onUnmounted } from "vue";
 import {
-  BookOpen,
   Settings,
   Link,
   ArrowRight,
@@ -167,6 +180,7 @@ import {
   FileCode,
   FileText,
   Workflow,
+  BookOpenText,
 } from "lucide-vue-next";
 
 const route = useRoute();

--- a/src/modules/tests/test.ts
+++ b/src/modules/tests/test.ts
@@ -22,10 +22,11 @@ export interface TestMetadata {
   category: string;
   setup: string[];
   relatedTests: string[];
-  sourceCode: {
+  documentation: {
     contract?: string;
     script?: string;
-    documentation?: string;
+    taqutioDocumentation?: string;
+    tezosDocumentation?: string;
   };
   component?: () => Promise<{ default: Component }>;
   diagrams?: TestDiagrams;

--- a/src/modules/tests/tests.ts
+++ b/src/modules/tests/tests.ts
@@ -13,10 +13,12 @@ export const AvailableTests: Record<string, TestMetadata> = {
       "Use a faucet to fund your wallet with testnet Tez from https://teztnets.com/",
     ],
     relatedTests: ["estimate-fees", "batch", "counter-contract"],
-    sourceCode: {
+    documentation: {
       script:
         "https://github.com/ecadlabs/taquito-test-dapp-vue/tree/main/src/modules/tests/tests/transfer",
-      documentation: "https://taquito.io/docs/making_transfers",
+      taqutioDocumentation: "https://taquito.io/docs/making_transfers",
+      tezosDocumentation:
+        "https://octez.tezos.com/docs/seoul/token_management.html",
     },
     component: () => import("@/modules/tests/tests/transfer/transfer-tez.vue"),
     diagrams: {
@@ -57,12 +59,14 @@ export const AvailableTests: Record<string, TestMetadata> = {
       "transaction-limit",
       "increase-paid-storage",
     ],
-    sourceCode: {
+    documentation: {
       contract:
         "https://github.com/ecadlabs/taquito-test-dapp-vue/blob/main/src/contracts/counter.jsligo",
       script:
         "https://github.com/ecadlabs/taquito-test-dapp-vue/tree/main/src/modules/tests/tests/counter",
-      documentation: "https://taquito.io/docs/smartcontracts",
+      taqutioDocumentation: "https://taquito.io/docs/smartcontracts",
+      tezosDocumentation:
+        "https://octez.tezos.com/docs/seoul/accounts.html#smart-contracts",
     },
     component: () =>
       import("@/modules/tests/tests/counter/counter-contract.vue"),
@@ -155,10 +159,12 @@ export const AvailableTests: Record<string, TestMetadata> = {
       "Configure Taquito with RPC endpoint and signer",
     ],
     relatedTests: ["counter-contract", "estimate-fees", "transaction-limit"],
-    sourceCode: {
+    documentation: {
       script:
         "https://github.com/ecadlabs/taquito-test-dapp-vue/tree/main/src/modules/tests/tests/increase-paid-storage",
-      documentation: "https://taquito.io/docs/increase_paid_storage",
+      taqutioDocumentation: "https://taquito.io/docs/increase_paid_storage",
+      tezosDocumentation:
+        "https://octez.tezos.com/docs/alpha/blocks_ops.html#manager-operations",
     },
     component: () =>
       import(
@@ -203,10 +209,10 @@ export const AvailableTests: Record<string, TestMetadata> = {
       "transaction-limit",
       "batch",
     ],
-    sourceCode: {
+    documentation: {
       script:
         "https://github.com/ecadlabs/taquito-test-dapp-vue/tree/main/src/modules/tests/tests/estimate-fees",
-      documentation: "https://taquito.io/docs/estimate",
+      taqutioDocumentation: "https://taquito.io/docs/estimate",
     },
     component: () =>
       import("@/modules/tests/tests/estimate-fees/estimate-fees.vue"),
@@ -235,10 +241,12 @@ export const AvailableTests: Record<string, TestMetadata> = {
       "Configure Taquito with RPC endpoint and signer",
     ],
     relatedTests: ["staking", "transfer", "estimate-fees"],
-    sourceCode: {
+    documentation: {
       script:
         "https://github.com/ecadlabs/taquito-test-dapp-vue/tree/main/src/modules/tests/tests/delegation",
-      documentation: "https://taquito.io/docs/set_delegate",
+      taqutioDocumentation: "https://taquito.io/docs/set_delegate",
+      tezosDocumentation:
+        "https://octez.tezos.com/docs/seoul/baking_power.html#delegate-delegators-stakers",
     },
     component: () => import("@/modules/tests/tests/delegation/delegation.vue"),
     diagrams: {
@@ -296,10 +304,12 @@ export const AvailableTests: Record<string, TestMetadata> = {
       "Configure Taquito with RPC endpoint and signer",
     ],
     relatedTests: ["delegation", "counter-contract", "estimate-fees"],
-    sourceCode: {
+    documentation: {
       script:
         "https://github.com/ecadlabs/taquito-test-dapp-vue/tree/main/src/modules/tests/tests/staking",
-      documentation: "https://taquito.io/docs/staking",
+      taqutioDocumentation: "https://taquito.io/docs/staking",
+      tezosDocumentation:
+        "https://octez.tezos.com/docs/seoul/baking_power.html#delegate-delegators-stakers",
     },
     component: () => import("@/modules/tests/tests/staking/staking.vue"),
     diagrams: {
@@ -384,10 +394,12 @@ export const AvailableTests: Record<string, TestMetadata> = {
       "estimate-fees",
       "delegation",
     ],
-    sourceCode: {
+    documentation: {
       script:
         "https://github.com/ecadlabs/taquito-test-dapp-vue/tree/main/src/modules/tests/tests/batch",
-      documentation: "https://taquito.io/docs/batch_API/",
+      taqutioDocumentation: "https://taquito.io/docs/batch_API/",
+      tezosDocumentation:
+        "https://octez.tezos.com/docs/seoul/blocks_ops.html#manager-operation-batches",
     },
     component: () => import("@/modules/tests/tests/batch/batch.vue"),
     diagrams: {
@@ -426,10 +438,10 @@ export const AvailableTests: Record<string, TestMetadata> = {
       "Understand the data you want to sign and its format",
     ],
     relatedTests: ["counter-contract", "estimate-fees"],
-    sourceCode: {
+    documentation: {
       script:
         "https://github.com/ecadlabs/taquito-test-dapp-vue/tree/main/src/modules/tests/tests/sign-payload",
-      documentation: "https://taquito.io/docs/signing/",
+      taqutioDocumentation: "https://taquito.io/docs/signing/",
     },
     component: () =>
       import("@/modules/tests/tests/sign-payload/sign-payload.vue"),
@@ -540,10 +552,10 @@ export const AvailableTests: Record<string, TestMetadata> = {
       "estimate-fees",
       "increase-paid-storage",
     ],
-    sourceCode: {
+    documentation: {
       script:
         "https://github.com/ecadlabs/taquito-test-dapp-vue/tree/main/src/modules/tests/tests/transaction-limit",
-      documentation: "https://taquito.io/docs/transaction_limits/",
+      taqutioDocumentation: "https://taquito.io/docs/transaction_limits/",
     },
     component: () =>
       import("@/modules/tests/tests/transaction-limit/transaction-limit.vue"),
@@ -587,10 +599,12 @@ export const AvailableTests: Record<string, TestMetadata> = {
       "Configure Taquito with RPC endpoint and signer",
     ],
     relatedTests: ["counter-contract", "transaction-limit", "estimate-fees"],
-    sourceCode: {
+    documentation: {
       script:
         "https://github.com/ecadlabs/taquito-test-dapp-vue/tree/main/src/modules/tests/tests/failing-noop",
-      documentation: "https://taquito.io/docs/failing_noop/",
+      taqutioDocumentation: "https://taquito.io/docs/failing_noop/",
+      tezosDocumentation:
+        "https://octez.tezos.com/docs/seoul/blocks_ops.html#failing-noop-operation",
     },
     component: () =>
       import("@/modules/tests/tests/failing-noop/failing-noop.vue"),


### PR DESCRIPTION
This pull request refactors how documentation links are managed and displayed for test modules. The main change is the consolidation of all documentation-related URLs under a new `documentation` object in the `TestMetadata` interface, allowing for both Taquito and Tezos documentation links. The UI is updated to reflect these changes, including new icons and link labels.

**Refactoring of documentation management:**

* Updated the `TestMetadata` interface in `test.ts` to replace the `sourceCode` object with a new `documentation` object, which now supports both `taqutioDocumentation` and `tezosDocumentation` links for each test.
* Refactored all test definitions in `tests.ts` to use the new `documentation` object, migrating existing documentation URLs and adding Tezos documentation links where relevant.

**UI updates for documentation links:**

* Updated `test-wrapper.vue` to display documentation links from the new `documentation` object, including separate links for Taquito and Tezos documentation, and revised logic for rendering contract and script links.
* Changed icon usage in the documentation link sections to use `BookOpenText` instead of `BookOpen`

**Minor UI improvements:**

* Removed unnecessary spacing class from the related tests section for a cleaner layout in `test-wrapper.vue`.