### PR TITLE
feat: implement global constants test

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,6 +3,7 @@ import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { RpcClient } from "@taquito/rpc";
 import type { Confirmation } from "@/types/wallet";
+import { toast } from "vue-sonner";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -36,4 +37,24 @@ export const getOperationHash = (confirmation: Confirmation) => {
     opHash = confirmation.toString();
   }
   return opHash;
+};
+
+/**
+ * Copies text to clipboard with toast notifications
+ * @param text - The text to copy to clipboard
+ * @param successMessage - Optional custom success message (default: "Copied to clipboard")
+ * @param errorMessage - Optional custom error message (default: "Failed to copy to clipboard")
+ */
+export const copyToClipboard = async (
+  text: string,
+  successMessage: string = "Copied to clipboard",
+  errorMessage: string = "Failed to copy to clipboard",
+) => {
+  try {
+    await navigator.clipboard.writeText(text);
+    toast.success(successMessage);
+  } catch (error) {
+    console.error("Failed to copy to clipboard:", error);
+    toast.error(errorMessage);
+  }
 };

--- a/src/modules/tests/tests.ts
+++ b/src/modules/tests/tests.ts
@@ -656,6 +656,54 @@ Michelson implements an instruction called 'CHECK_SIGNATURE' that allows it to r
       },
     },
   },
+  "global-constants": {
+    id: "global-constants",
+    title: "Global Constants",
+    description: `Global Constants allow users to register Michelson expressions in a global table and reference them across multiple contracts. This feature helps reduce contract size and storage costs by enabling code reuse.
+    
+    This is particularly useful for large contracts that exceed size limits or when sharing common code patterns between multiple contracts.`,
+    category: "Advanced Operations",
+    setup: [
+      "Install Taquito: `npm install @taquito/taquito`",
+      "Set up a Tezos wallet with sufficient Tez for registration fees",
+      "Configure Taquito with RPC endpoint and signer",
+      "Understand Michelson expressions and JSON format",
+      "Have sample expressions ready for testing",
+    ],
+    relatedTests: [
+      "counter-contract",
+      "estimate-fees",
+      "batch",
+      "sign-payload",
+    ],
+    documentation: {
+      script:
+        "https://github.com/ecadlabs/taquito-test-dapp-vue/tree/main/src/modules/tests/tests/global-constants",
+      taqutioDocumentation: "https://taquito.io/docs/global_constant/",
+      tezosDocumentation:
+        "https://octez.tezos.com/docs/seoul/global_constants.html",
+    },
+    component: () =>
+      import("@/modules/tests/tests/global-constants/global-constants.vue"),
+    diagrams: {
+      "register-constant": {
+        nodes: [
+          {
+            id: "estimate-fees",
+            label: "Estimate Fees",
+          },
+          {
+            id: "register-constant",
+            label: "Register Global Constant",
+          },
+          {
+            id: "wait-for-chain-confirmation",
+            label: "Wait for Chain Confirmation",
+          },
+        ],
+      },
+    },
+  },
 };
 
 export const getTestById = (id: string): TestMetadata | undefined => {

--- a/src/modules/tests/tests/global-constants/global-constants.ts
+++ b/src/modules/tests/tests/global-constants/global-constants.ts
@@ -24,8 +24,6 @@ const registerGlobalConstant = async (
 
   try {
     diagramStore.setProgress("estimate-fees", "running", TEST_ID);
-
-    // Estimate fees for the register_global_constant operation
     estimate = await Tezos.estimate.registerGlobalConstant({ value });
 
     if (estimate) {
@@ -37,12 +35,9 @@ const registerGlobalConstant = async (
     }
 
     diagramStore.setProgress("register-constant", "running", TEST_ID);
-
-    // Register the global constant
     const operation = await Tezos.contract.registerGlobalConstant({ value });
 
     diagramStore.setProgress("wait-for-chain-confirmation", "running", TEST_ID);
-
     const confirmation = await operation.confirmation(3);
 
     const opHash = getOperationHash(confirmation);
@@ -51,11 +46,9 @@ const registerGlobalConstant = async (
     }
 
     diagramStore.setProgress("success", "completed", TEST_ID);
-
-    // Return the global constant hash
     return operation.globalConstantHash;
   } catch (error) {
-    console.log(`Error: ${JSON.stringify(error, null, 2)}`);
+    console.error(`Error: ${JSON.stringify(error, null, 2)}`);
     diagramStore.setErrorMessage(error, TEST_ID);
     throw error;
   }

--- a/src/modules/tests/tests/global-constants/global-constants.ts
+++ b/src/modules/tests/tests/global-constants/global-constants.ts
@@ -1,0 +1,86 @@
+import { useWalletStore } from "@/stores/walletStore";
+import { useDiagramStore } from "@/stores/diagramStore";
+import { getOperationHash } from "@/lib/utils";
+import { PiggyBank } from "lucide-vue-next";
+import type { Estimate } from "@taquito/taquito";
+
+const TEST_ID = "global-constants";
+
+let estimate: Estimate;
+
+/**
+ * Registers a global constant with a Michelson expression
+ *
+ * @async
+ * @param {object} value - The Michelson expression to register
+ * @returns {Promise<string | undefined>} The hash of the registered constant
+ */
+const registerGlobalConstant = async (
+  value: object,
+): Promise<string | undefined> => {
+  const diagramStore = useDiagramStore();
+  const walletStore = useWalletStore();
+  const Tezos = walletStore.getTezos;
+
+  try {
+    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+
+    // Estimate fees for the register_global_constant operation
+    estimate = await Tezos.estimate.registerGlobalConstant({ value });
+
+    if (estimate) {
+      diagramStore.setNodeButton("estimate-fees", {
+        icon: PiggyBank,
+        text: "View Fees",
+        onClick: () => diagramStore.showFeeEstimationDialog(estimate),
+      });
+    }
+
+    diagramStore.setProgress("register-constant", "running", TEST_ID);
+
+    // Register the global constant
+    const operation = await Tezos.contract.registerGlobalConstant({ value });
+
+    diagramStore.setProgress("wait-for-chain-confirmation", "running", TEST_ID);
+
+    const confirmation = await operation.confirmation(3);
+
+    const opHash = getOperationHash(confirmation);
+    if (opHash) {
+      diagramStore.setOperationHash(opHash, TEST_ID);
+    }
+
+    diagramStore.setProgress("success", "completed", TEST_ID);
+
+    // Return the global constant hash
+    return operation.globalConstantHash;
+  } catch (error) {
+    console.log(`Error: ${JSON.stringify(error, null, 2)}`);
+    diagramStore.setErrorMessage(error, TEST_ID);
+    throw error;
+  }
+};
+
+/**
+ * Generates a sample Michelson expression with some randomness to avoid duplicates
+ *
+ * @returns {object} A sample Michelson expression
+ */
+const generateSampleExpression = (): object => {
+  // Generate a random number to add uniqueness
+  const randomValue = Math.floor(Math.random() * 1000000);
+
+  return {
+    prim: "pair",
+    args: [
+      { prim: "int" },
+      {
+        prim: "or",
+        args: [{ prim: "string" }, { prim: "nat" }],
+      },
+    ],
+    annots: [`%random_${randomValue}`],
+  };
+};
+
+export { registerGlobalConstant, generateSampleExpression };

--- a/src/modules/tests/tests/global-constants/global-constants.vue
+++ b/src/modules/tests/tests/global-constants/global-constants.vue
@@ -48,7 +48,7 @@
               <Button
                 variant="ghost"
                 size="icon"
-                :aria-label="`Copy hash ${registrationResult.hash}`"
+                :aria-label="`Copy constant hash`"
                 @click="
                   copyToClipboard(
                     registrationResult.hash,
@@ -67,7 +67,7 @@
               <Button
                 variant="ghost"
                 size="icon"
-                :aria-label="`Copy hash ${registrationResult.hash}`"
+                :aria-label="`Copy operation hash`"
                 @click="
                   copyToClipboard(
                     registrationResult.operationHash,

--- a/src/modules/tests/tests/global-constants/global-constants.vue
+++ b/src/modules/tests/tests/global-constants/global-constants.vue
@@ -1,0 +1,147 @@
+<template>
+  <div class="space-y-4">
+    <div class="space-y-4">
+      <!-- Michelson expression input -->
+      <div class="space-y-2">
+        <Label for="expression-input">Michelson Expression (JSON):</Label>
+        <Textarea
+          id="expression-input"
+          v-model="expressionInput"
+          placeholder="Enter Michelson expression in JSON format..."
+          class="min-h-32 font-mono text-sm"
+        />
+      </div>
+
+      <div class="flex-col sm:flex-row flex gap-2">
+        <Button
+          @click="registerConstant"
+          :disabled="
+            !walletConnected || !expressionInput.trim() || isRegistering
+          "
+        >
+          <Loader2 v-if="isRegistering" class="mr-2 h-4 w-4 animate-spin" />
+          <Hash v-else class="mr-2 h-4 w-4" />
+          {{ isRegistering ? "Registering..." : "Register Constant" }}
+        </Button>
+        <Button variant="outline" @click="generateRandomExpression">
+          <Shuffle class="mr-2 h-4 w-4" />
+          Generate Random
+        </Button>
+      </div>
+
+      <!-- Registration result -->
+      <div v-if="registrationResult" class="space-y-2">
+        <div class="p-4 bg-muted rounded-md">
+          <div class="space-y-2">
+            <div class="flex items-center gap-2">
+              <Check class="h-4 w-4 text-green-500" />
+              <span class="font-medium">Constant Registered Successfully!</span>
+            </div>
+            <div class="text-sm flex items-center">
+              <span class="font-medium">Hash:</span>
+              <code
+                class="ml-2 p-1 bg-background rounded text-xs max-w-full inline-block overflow-hidden text-ellipsis whitespace-nowrap"
+                :title="registrationResult.hash"
+              >
+                {{ registrationResult.hash }}
+              </code>
+              <Button
+                variant="ghost"
+                size="icon"
+                :aria-label="`Copy hash ${registrationResult.hash}`"
+                @click="
+                  copyToClipboard(
+                    registrationResult.hash,
+                    'Hash copied to clipboard',
+                  )
+                "
+              >
+                <CopyIcon class="size-3" />
+              </Button>
+            </div>
+            <div class="text-sm flex items-center">
+              <span class="font-medium">Operation Hash:</span>
+              <code class="ml-2 p-1 bg-background rounded text-xs">{{
+                registrationResult.operationHash
+              }}</code>
+              <Button
+                variant="ghost"
+                size="icon"
+                :aria-label="`Copy hash ${registrationResult.hash}`"
+                @click="
+                  copyToClipboard(
+                    registrationResult.operationHash,
+                    'Operation hash copied to clipboard',
+                  )
+                "
+              >
+                <CopyIcon class="size-3" />
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useDiagramStore } from "@/stores/diagramStore";
+import { useWalletStore } from "@/stores/walletStore";
+import Button from "@/components/ui/button/Button.vue";
+import Textarea from "@/components/ui/textarea/Textarea.vue";
+import Label from "@/components/ui/label/Label.vue";
+import { copyToClipboard } from "@/lib/utils";
+import { Hash, Loader2, Check, Shuffle, CopyIcon } from "lucide-vue-next";
+import {
+  registerGlobalConstant,
+  generateSampleExpression,
+} from "@/modules/tests/tests/global-constants/global-constants";
+import { computed, onMounted, ref } from "vue";
+
+const diagramStore = useDiagramStore();
+const walletStore = useWalletStore();
+
+const walletConnected = computed(() => !!walletStore.getAddress);
+const expressionInput = ref("");
+const isRegistering = ref(false);
+const registrationResult = ref<{ hash: string; operationHash: string } | null>(
+  null,
+);
+
+onMounted(() => {
+  diagramStore.setTestDiagram("global-constants");
+});
+
+const generateRandomExpression = () => {
+  const randomExpression = generateSampleExpression();
+  expressionInput.value = JSON.stringify(randomExpression, null, 2);
+};
+
+const registerConstant = async () => {
+  isRegistering.value = true;
+  registrationResult.value = null;
+
+  try {
+    const expression = JSON.parse(expressionInput.value);
+
+    const expressionHash = await registerGlobalConstant(expression);
+
+    if (expressionHash) {
+      const operationHash = diagramStore.operationHash;
+
+      registrationResult.value = {
+        hash: expressionHash,
+        operationHash:
+          (typeof operationHash === "string"
+            ? operationHash
+            : operationHash?.toString()) ?? "N/A",
+      };
+    }
+  } catch (error) {
+    console.error("Registration error:", error);
+  } finally {
+    isRegistering.value = false;
+  }
+};
+</script>

--- a/tests/global-constants.spec.ts
+++ b/tests/global-constants.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+import { getSharedPage, setupSharedContext } from "./shared-context.ts";
+import { goToTest, waitForSuccess } from "./helpers.ts";
+
+test.describe("Global Constants", () => {
+  test.beforeAll(async () => {
+    await setupSharedContext();
+  });
+
+  test("should register a global constant", async () => {
+    const page = getSharedPage();
+    await goToTest({ page, testName: "Global Constants" });
+    await page.getByRole("button", { name: "Generate Random" }).click();
+    await expect(page.locator("#expression-input")).not.toHaveValue("", {
+      timeout: 5000,
+    });
+    await page.getByRole("button", { name: "Register Constant" }).click();
+
+    await waitForSuccess({ page });
+  });
+});


### PR DESCRIPTION
This pull request introduces support for Tezos global constants, enabling users to register Michelson expressions as global constants and reference them across contracts. The main changes include a new test module for global constants, a Vue component for user interaction, utility improvements for clipboard operations, and an end-to-end Playwright test for the new feature.

Closes #36 

**Global Constants Feature Implementation:**

* Added a new test metadata entry for "Global Constants" in `tests.ts`, including setup instructions, documentation links, related tests, and a diagram describing the registration flow.
* Created the `global-constants.ts` module, providing functions to register a Michelson expression as a global constant and generate sample expressions for testing.
* Developed the `global-constants.vue` component, allowing users to input Michelson expressions, generate random samples, register constants, and copy resulting hashes with feedback.

**Utility and User Experience Enhancements:**

* Added a reusable `copyToClipboard` utility function to `utils.ts`, which shows toast notifications on success or error using `vue-sonner`.

**Testing:**

* Implemented a Playwright test to verify the global constant registration flow, including generating a random expression and confirming successful registration.