### PR TITLE
feat: implement contract call failure test

### DIFF
--- a/src/components/test-diagram.vue
+++ b/src/components/test-diagram.vue
@@ -61,6 +61,14 @@
               data-testid="diagramComplete"
               tabindex="-1"
             />
+            <!-- Locator for automated tests to know when an example has errored -->
+            <div
+              v-if="node.type === 'error' && diagramStatus === 'errored'"
+              class="absolute top-0 left-0 sr-only"
+              aria-hidden="true"
+              data-testid="diagramError"
+              tabindex="-1"
+            />
             <a
               v-if="
                 node.type === 'success' &&

--- a/src/modules/tests/tests.ts
+++ b/src/modules/tests/tests.ts
@@ -656,6 +656,49 @@ Michelson implements an instruction called 'CHECK_SIGNATURE' that allows it to r
       },
     },
   },
+  "failing-contract": {
+    id: "failing-contract",
+    title: "Contract Call Failures",
+    description: `This test demonstrates how Taquito handles various contract call failure scenarios. Understanding error modes is crucial for building robust dApps that can gracefully handle different types of contract interaction failures.
+
+    Different types of errors include parameter type mismatches, invalid entrypoint calls, and malformed parameter structures.`,
+    category: "Smart Contracts",
+    setup: [
+      "Install Taquito: `npm install @taquito/taquito`",
+      "Set up a Tezos wallet with sufficient Tez for gas fees",
+      "Deploy or obtain access to a contract with entry points",
+      "Configure Taquito with RPC endpoint and signer",
+      "Understand the contract's entrypoints and expected parameters",
+    ],
+    relatedTests: ["counter-contract", "failing-noop", "estimate-fees"],
+    documentation: {
+      script:
+        "https://github.com/ecadlabs/taquito-test-dapp-vue/tree/main/src/modules/tests/tests/failing-contract",
+      taqutioDocumentation: "https://taquito.io/docs/smartcontracts",
+      tezosDocumentation:
+        "https://octez.tezos.com/docs/seoul/accounts.html#smart-contracts",
+    },
+    component: () =>
+      import("@/modules/tests/tests/failing-contract/failing-contract.vue"),
+    diagrams: {
+      "failing-contract": {
+        nodes: [
+          {
+            id: "get-contract",
+            label: "Get Contract",
+          },
+          {
+            id: "execute-operation",
+            label: "Execute Operation",
+          },
+          {
+            id: "wait-confirmation",
+            label: "Wait for Confirmation",
+          },
+        ],
+      },
+    },
+  },
   "global-constants": {
     id: "global-constants",
     title: "Global Constants",

--- a/src/modules/tests/tests/failing-contract/failing-contract.ts
+++ b/src/modules/tests/tests/failing-contract/failing-contract.ts
@@ -1,0 +1,70 @@
+import { useWalletStore } from "@/stores/walletStore";
+import { useDiagramStore } from "@/stores/diagramStore";
+import contracts from "@/contracts/contract-config.json";
+import { type ContractConfig } from "@/types/contract";
+
+const CONTRACT_ADDRESS =
+  (contracts as ContractConfig[]).find(
+    (contract: ContractConfig) => contract.contractName === "counter",
+  )?.address ?? "";
+const TEST_ID = "failing-contract";
+
+/**
+ * Attempts to call a contract with invalid parameters to test error handling.
+ *
+ * @async
+ * @param {string} scenario - The type of failure scenario to test
+ * @returns {Promise<void>} Resolves when the operation fails or errors are handled.
+ */
+const testContractFailure = async (scenario: string): Promise<void> => {
+  const diagramStore = useDiagramStore();
+  const walletStore = useWalletStore();
+  const Tezos = walletStore.getTezos;
+
+  try {
+    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
+
+    let operation;
+
+    diagramStore.setProgress("execute-operation", "running", TEST_ID);
+
+    switch (scenario) {
+      case "wrong-type":
+        // Try to pass a string instead of a number to increment
+        operation = await contract.methodsObject
+          .increment("invalid" as any)
+          .send();
+        break;
+
+      case "invalid-entrypoint":
+        // Try to call a non-existent entrypoint
+        operation = await (contract as any).methodsObject
+          .nonExistentMethod()
+          .send();
+        break;
+
+      case "invalid-parameter-structure":
+        // Try to pass wrong parameter structure
+        operation = await contract.methodsObject
+          .increment({ invalid: "structure" } as any)
+          .send();
+        break;
+
+      default:
+        throw new Error(`Unknown scenario: ${scenario}`);
+    }
+
+    throw new Error(
+      "Operation unexpectedly succeeded. This should not happen, as this test is designed to fail.",
+    );
+  } catch (error) {
+    console.log(
+      `Expected contract call failure for scenario '${scenario}':`,
+      JSON.stringify(error, null, 2),
+    );
+    diagramStore.setErrorMessage(error, TEST_ID);
+  }
+};
+
+export { testContractFailure };

--- a/src/modules/tests/tests/failing-contract/failing-contract.vue
+++ b/src/modules/tests/tests/failing-contract/failing-contract.vue
@@ -1,0 +1,121 @@
+<template>
+  <div class="flex flex-col items-center w-full justify-center gap-6">
+    <div class="flex flex-col items-center gap-4 p-4">
+      <h4 class="text-md font-medium">Failure Scenarios</h4>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3 w-full max-w-2xl">
+        <Button
+          @click="() => testFailure('wrong-type')"
+          :disabled="!walletConnected || isLoading"
+          variant="destructive"
+        >
+          <Loader2
+            v-if="isLoading && currentTest === 'wrong-type'"
+            class="animate-spin mr-2 h-4 w-4"
+          />
+          <XCircle v-else class="mr-2 h-4 w-4" />
+          Wrong Type
+        </Button>
+
+        <Button
+          @click="() => testFailure('invalid-entrypoint')"
+          :disabled="!walletConnected || isLoading"
+          variant="destructive"
+        >
+          <Loader2
+            v-if="isLoading && currentTest === 'invalid-entrypoint'"
+            class="animate-spin mr-2 h-4 w-4"
+          />
+          <XCircle v-else class="mr-2 h-4 w-4" />
+          Invalid Entrypoint
+        </Button>
+
+        <Button
+          @click="() => testFailure('invalid-parameter-structure')"
+          :disabled="!walletConnected || isLoading"
+          variant="destructive"
+        >
+          <Loader2
+            v-if="isLoading && currentTest === 'invalid-parameter-structure'"
+            class="animate-spin mr-2 h-4 w-4"
+          />
+          <XCircle v-else class="mr-2 h-4 w-4" />
+          Invalid Structure
+        </Button>
+      </div>
+    </div>
+
+    <!-- Error Visualization Section -->
+    <div
+      v-if="errorMessage"
+      class="w-full max-w-2xl p-4 border border-red-200 rounded-lg bg-red-50"
+    >
+      <h4 class="text-md font-medium text-red-800 mb-2 flex items-center">
+        <AlertTriangle class="mr-2 h-4 w-4" />
+        Error Details
+      </h4>
+      <div class="bg-red-100 p-3 rounded border text-sm">
+        <pre
+          class="whitespace-pre-wrap text-red-700 font-mono text-xs overflow-auto"
+          >{{ formattedError }}</pre
+        >
+      </div>
+      <p class="text-xs text-red-600 mt-2">
+        This error was expected and demonstrates how Taquito handles contract
+        call failures.
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useDiagramStore } from "@/stores/diagramStore";
+import { computed, onMounted, ref, watch } from "vue";
+import { useWalletStore } from "@/stores/walletStore";
+import { testContractFailure } from "@/modules/tests/tests/failing-contract/failing-contract";
+import { Loader2, XCircle, AlertTriangle } from "lucide-vue-next";
+import Button from "@/components/ui/button/Button.vue";
+
+const diagramStore = useDiagramStore();
+const walletStore = useWalletStore();
+
+const walletConnected = computed(() => !!walletStore.getAddress);
+const isLoading = ref<boolean>(false);
+const currentTest = ref<string>("");
+const errorMessage = ref();
+
+const formattedError = computed(() => {
+  if (!errorMessage.value) return "";
+
+  try {
+    return typeof errorMessage.value === "string"
+      ? errorMessage.value
+      : JSON.stringify(errorMessage.value, null, 2);
+  } catch {
+    return String(errorMessage.value);
+  }
+});
+
+// Watch for errors from the diagram store
+watch(
+  () => diagramStore.errorMessage,
+  (newError) => {
+    if (newError) {
+      errorMessage.value = newError;
+      isLoading.value = false;
+      currentTest.value = "";
+    }
+  },
+);
+
+onMounted(() => {
+  diagramStore.setTestDiagram("failing-contract");
+});
+
+const testFailure = async (scenario: string) => {
+  isLoading.value = true;
+  currentTest.value = scenario;
+  errorMessage.value = null;
+  await testContractFailure(scenario);
+};
+</script>

--- a/tests/failing-contract.spec.ts
+++ b/tests/failing-contract.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+import { getSharedPage, setupSharedContext } from "./shared-context.ts";
+import { goToTest, waitForSuccess, waitForError } from "./helpers.ts";
+
+test.describe("Contract Call Failures", () => {
+  test.beforeAll(async () => {
+    await setupSharedContext();
+  });
+
+  test("should handle wrong parameter type error", async () => {
+    const page = getSharedPage();
+    await goToTest({ page, testName: "Contract Call Failures" });
+
+    await page.getByRole("button", { name: "Wrong Type" }).click();
+
+    // The operation should fail and display error information
+    await waitForError({ page });
+
+    // Verify error message is displayed
+    await expect(page.getByText("Error Details")).toBeVisible();
+    await expect(page.getByText("This error was expected")).toBeVisible();
+  });
+
+  test("should handle invalid entrypoint error", async () => {
+    const page = getSharedPage();
+    await goToTest({ page, testName: "Contract Call Failures" });
+
+    await page.getByRole("button", { name: "Invalid Entrypoint" }).click();
+
+    // The operation should fail and display error information
+    await waitForError({ page });
+
+    // Verify error message is displayed
+    await expect(page.getByText("Error Details")).toBeVisible();
+    await expect(page.getByText("This error was expected")).toBeVisible();
+  });
+
+  test("should handle invalid parameter structure error", async () => {
+    const page = getSharedPage();
+    await goToTest({ page, testName: "Contract Call Failures" });
+
+    await page.getByRole("button", { name: "Invalid Structure" }).click();
+
+    // The operation should fail and display error information
+    await waitForError({ page });
+
+    // Verify error message is displayed
+    await expect(page.getByText("Error Details")).toBeVisible();
+    await expect(page.getByText("This error was expected")).toBeVisible();
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -32,8 +32,16 @@ export const goToTest = async ({
 };
 
 export const waitForSuccess = async ({ page }: { page: Page }) => {
-  // Wait for the diagram to complete with a longer timeout for blockchain operations
+  // Wait for the diagram to complete
   await page.waitForSelector('div[data-testid="diagramComplete"]', {
+    timeout: 60000, // Increased timeout for blockchain operations
+    state: "visible",
+  });
+};
+
+export const waitForError = async ({ page }: { page: Page }) => {
+  // Wait for the diagram to enter an error state
+  await page.waitForSelector('div[data-testid="diagramError"]', {
     timeout: 60000, // Increased timeout for blockchain operations
     state: "visible",
   });


### PR DESCRIPTION
This pull request introduces a new test scenario for contract call failures.

Closes #37 

**New "Contract Call Failures" Test Feature:**

* Added a new test case, `"failing-contract"`, to `tests.ts` that demonstrates how Taquito handles contract call failures, including wrong parameter types, invalid entrypoints, and malformed parameter structures. Includes metadata, setup instructions, and diagram nodes.
* Implemented the backend logic in `failing-contract.ts` to attempt contract calls with invalid parameters, handle expected errors, and update the diagram/error state accordingly.
* Created a new Vue component, `failing-contract.vue`, providing UI buttons for each failure scenario, visual error feedback, and integration with wallet/diagram stores.

**Automated Testing Improvements:**

* Added end-to-end Playwright tests in `failing-contract.spec.ts` to verify that each failure scenario results in the correct error handling and user feedback in the UI.
* Enhanced diagram testability by adding a `diagramError` locator to `test-diagram.vue`, allowing automated tests to detect when an error state is displayed.
* Introduced a `waitForError` helper in `helpers.ts` to wait for the error state in automated tests, improving reliability and clarity of test flows.