### PR TITLE
task: simplify setting test diagram steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,9 +126,6 @@ const CONTRACT_ADDRESS =
     (contract: ContractConfig) => contract.contractName === "your-contract",
   )?.address ?? "";
 
-// The TEST_ID constant is to help keep the code clean, as we use it often in diagram helpers.
-const TEST_ID = "your-test-name";
-
 /**
  * Main test function description
  *
@@ -142,26 +139,26 @@ export const mainTestFunction = async (param: string): Promise<void> => {
 
   // Tell the diagram store which diagram we're using
   // IMPORTANT: You should set a default diagram in the vue component onMounted hook later
-  diagramStore.setTestDiagram(TEST_ID, "my-diagram");
+  diagramStore.setTestDiagram("my-test-name", "my-diagram");
 
   // Always surround your test logic in a try/catch
   try {
     // Update diagram progress as you go using the ID of the step.
     // Do this before running each actual logic step (so time tracking is accurate)
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("execute-contract", "running", TEST_ID);
+    diagramStore.setProgress("execute-contract");
     const operation = await contract.methodsObject.yourMethod(param).send();
 
-    diagramStore.setProgress("wait-for-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-confirmation");
     await operation.confirmation(3);
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     // If something goes wrong, log the error but also ensure you display it to the user in the diagram
     console.error("Error:", error);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 ```
@@ -201,7 +198,7 @@ const walletStore = useWalletStore();
 const walletConnected = computed(() => !!walletStore.getAddress);
 
 onMounted(() => {
-  diagramStore.setTestDiagram("my-default-diagram");
+  diagramStore.setTestDiagram("my-test-name", "my-default-diagram");
 });
 </script>
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ export const mainTestFunction = async (param: string): Promise<void> => {
     diagramStore.setProgress("wait-for-confirmation", "running", TEST_ID);
     await operation.confirmation(3);
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     // If something goes wrong, log the error but also ensure you display it to the user in the diagram
     console.error("Error:", error);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,7 @@ export const mainTestFunction = async (param: string): Promise<void> => {
   const Tezos = walletStore.getTezos;
 
   // Tell the diagram store which diagram we're using
+  // IMPORTANT: You should set a default diagram in the vue component onMounted hook later
   diagramStore.setTestDiagram(TEST_ID, "my-diagram");
 
   // Always surround your test logic in a try/catch
@@ -198,6 +199,10 @@ import { ref, computed } from "vue";
 
 const walletStore = useWalletStore();
 const walletConnected = computed(() => !!walletStore.getAddress);
+
+onMounted(() => {
+  diagramStore.setTestDiagram("my-default-diagram");
+});
 </script>
 ```
 

--- a/src/modules/tests/tests/batch/batch.ts
+++ b/src/modules/tests/tests/batch/batch.ts
@@ -4,8 +4,6 @@ import { useDiagramStore } from "@/stores/diagramStore";
 import { useWalletStore } from "@/stores/walletStore";
 import type { ContractConfig } from "@/types/contract";
 
-const TEST_ID = "batch";
-
 const CONTRACT_ADDRESS =
   (contracts as ContractConfig[]).find(
     (contract: ContractConfig) => contract.contractName === "counter",
@@ -23,28 +21,28 @@ const sendBatch = async (): Promise<void> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("create-batch", "running", TEST_ID);
+    diagramStore.setProgress("create-batch", "running");
     const batch = Tezos.wallet.batch();
 
     if (!walletStore.getAddress) throw new Error("No wallet address found");
 
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("add-operations", "running", TEST_ID);
+    diagramStore.setProgress("add-operations", "running");
     batch.withTransfer({ to: walletStore.getAddress, amount: 1 });
     batch.withContractCall(contract.methodsObject.increment(1));
 
-    diagramStore.setProgress("wait-for-user", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-user", "running");
     const batchOp = await batch.send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-chain-confirmation", "running");
     const confirmation = await batchOp.confirmation();
     const opHash = getOperationHash(confirmation);
-    diagramStore.setOperationHash(opHash, TEST_ID);
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setOperationHash(opHash);
+    diagramStore.setCompleted();
   } catch (error) {
     console.log(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 

--- a/src/modules/tests/tests/batch/batch.ts
+++ b/src/modules/tests/tests/batch/batch.ts
@@ -41,7 +41,7 @@ const sendBatch = async (): Promise<void> => {
     const confirmation = await batchOp.confirmation();
     const opHash = getOperationHash(confirmation);
     diagramStore.setOperationHash(opHash, TEST_ID);
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.log(`Error: ${JSON.stringify(error, null, 2)}`);
     diagramStore.setErrorMessage(error, TEST_ID);

--- a/src/modules/tests/tests/batch/batch.ts
+++ b/src/modules/tests/tests/batch/batch.ts
@@ -21,21 +21,21 @@ const sendBatch = async (): Promise<void> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("create-batch", "running");
+    diagramStore.setProgress("create-batch");
     const batch = Tezos.wallet.batch();
 
     if (!walletStore.getAddress) throw new Error("No wallet address found");
 
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("add-operations", "running");
+    diagramStore.setProgress("add-operations");
     batch.withTransfer({ to: walletStore.getAddress, amount: 1 });
     batch.withContractCall(contract.methodsObject.increment(1));
 
-    diagramStore.setProgress("wait-for-user", "running");
+    diagramStore.setProgress("wait-for-user");
     const batchOp = await batch.send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running");
+    diagramStore.setProgress("wait-for-chain-confirmation");
     const confirmation = await batchOp.confirmation();
     const opHash = getOperationHash(confirmation);
     diagramStore.setOperationHash(opHash);

--- a/src/modules/tests/tests/complex-parameters/complex-parameters.ts
+++ b/src/modules/tests/tests/complex-parameters/complex-parameters.ts
@@ -68,7 +68,7 @@ const addUserRecord = async (record: RecordParam): Promise<void> => {
     if (confirmation?.block.hash) {
       diagramStore.setOperationHash(confirmation.block.hash, TEST_ID);
     }
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
     diagramStore.setErrorMessage(error, TEST_ID);
@@ -139,7 +139,7 @@ const setNestedRecord = async (nestedRecord: NestedRecord): Promise<void> => {
     if (confirmation?.block.hash) {
       diagramStore.setOperationHash(confirmation.block.hash, TEST_ID);
     }
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
     diagramStore.setErrorMessage(error, TEST_ID);
@@ -199,7 +199,7 @@ const manageUserSet = async (
     if (confirmation?.block.hash) {
       diagramStore.setOperationHash(confirmation.block.hash, TEST_ID);
     }
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
     diagramStore.setErrorMessage(error, TEST_ID);
@@ -251,7 +251,7 @@ const updateMetadata = async (
     if (confirmation?.block.hash) {
       diagramStore.setOperationHash(confirmation.block.hash, TEST_ID);
     }
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
     diagramStore.setErrorMessage(error, TEST_ID);
@@ -284,7 +284,7 @@ const getUserRecord = async (
       .get_user_record(userAddress)
       .executeView({ viewCaller: userAddress });
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
     return result;
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
@@ -320,7 +320,7 @@ const getNestedData = async (
       .get_nested_record(userAddress)
       .executeView({ viewCaller: userAddress });
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
     return result;
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
@@ -370,7 +370,7 @@ const getAllMetadata = async (): Promise<Record<string, string> | null> => {
       throw new Error("Result is not a map");
     }
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
     return cleanMetadata;
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);

--- a/src/modules/tests/tests/complex-parameters/complex-parameters.ts
+++ b/src/modules/tests/tests/complex-parameters/complex-parameters.ts
@@ -40,10 +40,10 @@ const addUserRecord = async (record: RecordParam): Promise<void> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     const transferParams = await contract.methodsObject
       .add_user_record(record)
       .toTransferParams();
@@ -57,12 +57,12 @@ const addUserRecord = async (record: RecordParam): Promise<void> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running");
+    diagramStore.setProgress("execute-operation");
     const operation = await contract.methodsObject
       .add_user_record(record)
       .send();
 
-    diagramStore.setProgress("wait-confirmation", "running");
+    diagramStore.setProgress("wait-confirmation");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
@@ -91,7 +91,7 @@ const setNestedRecord = async (nestedRecord: NestedRecord): Promise<void> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
     const cleanString = (str: string) => str.replace(/[^\x20-\x7E]/g, ""); // Keep only printable ASCII
 
@@ -114,7 +114,7 @@ const setNestedRecord = async (nestedRecord: NestedRecord): Promise<void> => {
           : ["read"],
     };
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     const transferParams = await contract.methodsObject
       .set_nested_record(complexData)
       .toTransferParams();
@@ -128,12 +128,12 @@ const setNestedRecord = async (nestedRecord: NestedRecord): Promise<void> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running");
+    diagramStore.setProgress("execute-operation");
     const operation = await contract.methodsObject
       .set_nested_record(complexData)
       .send();
 
-    diagramStore.setProgress("wait-confirmation", "running");
+    diagramStore.setProgress("wait-confirmation");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
@@ -166,7 +166,7 @@ const manageUserSet = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
     const params = {
@@ -174,7 +174,7 @@ const manageUserSet = async (
       user: userAddress,
     };
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     const transferParams = await contract.methodsObject
       .manage_authorization(params)
       .toTransferParams();
@@ -188,12 +188,12 @@ const manageUserSet = async (
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running");
+    diagramStore.setProgress("execute-operation");
     const operation = await contract.methodsObject
       .manage_authorization(params)
       .send();
 
-    diagramStore.setProgress("wait-confirmation", "running");
+    diagramStore.setProgress("wait-confirmation");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
@@ -223,10 +223,10 @@ const updateMetadata = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     const transferParams = await contract.methodsObject
       .update_metadata(updates)
       .toTransferParams();
@@ -240,12 +240,12 @@ const updateMetadata = async (
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running");
+    diagramStore.setProgress("execute-operation");
     const operation = await contract.methodsObject
       .update_metadata(updates)
       .send();
 
-    diagramStore.setProgress("wait-confirmation", "running");
+    diagramStore.setProgress("wait-confirmation");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
@@ -276,10 +276,10 @@ const getUserRecord = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("read-storage", "running");
+    diagramStore.setProgress("read-storage");
     const result = await contract.contractViews
       .get_user_record(userAddress)
       .executeView({ viewCaller: userAddress });
@@ -312,10 +312,10 @@ const getNestedData = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("read-storage", "running");
+    diagramStore.setProgress("read-storage");
     const result = await contract.contractViews
       .get_nested_record(userAddress)
       .executeView({ viewCaller: userAddress });
@@ -343,14 +343,14 @@ const getAllMetadata = async (): Promise<Record<string, string> | null> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
     const address = walletStore.getAddress;
     if (!address) {
       throw new Error("No wallet address found");
     }
 
-    diagramStore.setProgress("read-storage", "running");
+    diagramStore.setProgress("read-storage");
 
     // The result type is expected to have a valueMap property of type Map<string, string>
     type MetadataViewResult = { valueMap: Map<string, string> };

--- a/src/modules/tests/tests/complex-parameters/complex-parameters.ts
+++ b/src/modules/tests/tests/complex-parameters/complex-parameters.ts
@@ -40,10 +40,10 @@ const addUserRecord = async (record: RecordParam): Promise<void> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     const transferParams = await contract.methodsObject
       .add_user_record(record)
       .toTransferParams();
@@ -57,21 +57,21 @@ const addUserRecord = async (record: RecordParam): Promise<void> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running", TEST_ID);
+    diagramStore.setProgress("execute-operation", "running");
     const operation = await contract.methodsObject
       .add_user_record(record)
       .send();
 
-    diagramStore.setProgress("wait-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-confirmation", "running");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
-      diagramStore.setOperationHash(confirmation.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation.block.hash);
     }
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 
@@ -91,7 +91,7 @@ const setNestedRecord = async (nestedRecord: NestedRecord): Promise<void> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
     const cleanString = (str: string) => str.replace(/[^\x20-\x7E]/g, ""); // Keep only printable ASCII
 
@@ -114,7 +114,7 @@ const setNestedRecord = async (nestedRecord: NestedRecord): Promise<void> => {
           : ["read"],
     };
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     const transferParams = await contract.methodsObject
       .set_nested_record(complexData)
       .toTransferParams();
@@ -128,21 +128,21 @@ const setNestedRecord = async (nestedRecord: NestedRecord): Promise<void> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running", TEST_ID);
+    diagramStore.setProgress("execute-operation", "running");
     const operation = await contract.methodsObject
       .set_nested_record(complexData)
       .send();
 
-    diagramStore.setProgress("wait-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-confirmation", "running");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
-      diagramStore.setOperationHash(confirmation.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation.block.hash);
     }
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 
@@ -166,7 +166,7 @@ const manageUserSet = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
     const params = {
@@ -174,7 +174,7 @@ const manageUserSet = async (
       user: userAddress,
     };
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     const transferParams = await contract.methodsObject
       .manage_authorization(params)
       .toTransferParams();
@@ -188,21 +188,21 @@ const manageUserSet = async (
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running", TEST_ID);
+    diagramStore.setProgress("execute-operation", "running");
     const operation = await contract.methodsObject
       .manage_authorization(params)
       .send();
 
-    diagramStore.setProgress("wait-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-confirmation", "running");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
-      diagramStore.setOperationHash(confirmation.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation.block.hash);
     }
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 
@@ -223,10 +223,10 @@ const updateMetadata = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     const transferParams = await contract.methodsObject
       .update_metadata(updates)
       .toTransferParams();
@@ -240,21 +240,21 @@ const updateMetadata = async (
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running", TEST_ID);
+    diagramStore.setProgress("execute-operation", "running");
     const operation = await contract.methodsObject
       .update_metadata(updates)
       .send();
 
-    diagramStore.setProgress("wait-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-confirmation", "running");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
-      diagramStore.setOperationHash(confirmation.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation.block.hash);
     }
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 
@@ -276,19 +276,19 @@ const getUserRecord = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("read-storage", "running", TEST_ID);
+    diagramStore.setProgress("read-storage", "running");
     const result = await contract.contractViews
       .get_user_record(userAddress)
       .executeView({ viewCaller: userAddress });
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
     return result;
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     return null;
   }
 };
@@ -312,19 +312,19 @@ const getNestedData = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("read-storage", "running", TEST_ID);
+    diagramStore.setProgress("read-storage", "running");
     const result = await contract.contractViews
       .get_nested_record(userAddress)
       .executeView({ viewCaller: userAddress });
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
     return result;
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     return null;
   }
 };
@@ -343,14 +343,14 @@ const getAllMetadata = async (): Promise<Record<string, string> | null> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
     const address = walletStore.getAddress;
     if (!address) {
       throw new Error("No wallet address found");
     }
 
-    diagramStore.setProgress("read-storage", "running", TEST_ID);
+    diagramStore.setProgress("read-storage", "running");
 
     // The result type is expected to have a valueMap property of type Map<string, string>
     type MetadataViewResult = { valueMap: Map<string, string> };
@@ -370,11 +370,11 @@ const getAllMetadata = async (): Promise<Record<string, string> | null> => {
       throw new Error("Result is not a map");
     }
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
     return cleanMetadata;
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     return null;
   }
 };

--- a/src/modules/tests/tests/counter/counter-contract.ts
+++ b/src/modules/tests/tests/counter/counter-contract.ts
@@ -36,12 +36,12 @@ const increment = async (amount: number): Promise<number | undefined> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
 
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
     console.log(`Incrementing storage value by ${amount}...`);
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     const transferParams = await contract.methodsObject
       .increment(amount)
       .toTransferParams();
@@ -55,11 +55,11 @@ const increment = async (amount: number): Promise<number | undefined> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running");
+    diagramStore.setProgress("execute-operation");
 
     const operation = await contract.methodsObject.increment(amount).send();
 
-    diagramStore.setProgress("wait-confirmation", "running");
+    diagramStore.setProgress("wait-confirmation");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash)
@@ -95,10 +95,10 @@ const decrement = async (amount: number): Promise<number | undefined> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     const transferParams = await contract.methodsObject
       .decrement(amount)
       .toTransferParams();
@@ -112,9 +112,9 @@ const decrement = async (amount: number): Promise<number | undefined> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running");
+    diagramStore.setProgress("execute-operation");
     const operation = await contract.methodsObject.decrement(amount).send();
-    diagramStore.setProgress("wait-confirmation", "running");
+    diagramStore.setProgress("wait-confirmation");
     const confirmation = await operation.confirmation(3);
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash);
@@ -141,10 +141,10 @@ const reset = async (): Promise<void> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     const transferParams = await contract.methodsObject
       .reset()
       .toTransferParams();
@@ -158,9 +158,9 @@ const reset = async (): Promise<void> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running");
+    diagramStore.setProgress("execute-operation");
     const operation = await contract.methodsObject.reset().send();
-    diagramStore.setProgress("wait-confirmation", "running");
+    diagramStore.setProgress("wait-confirmation");
     const confirmation = await operation.confirmation(3);
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash);
@@ -188,12 +188,12 @@ const getContractStorage = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    if (!noDiagram) diagramStore.setProgress("get-contract", "running");
+    if (!noDiagram) diagramStore.setProgress("get-contract");
 
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
     const storage = await contract.storage();
     console.log(`Current storage value: ${storage}`);
-    if (!noDiagram) diagramStore.setProgress("read-storage", "running");
+    if (!noDiagram) diagramStore.setProgress("read-storage");
     if (!noDiagram) diagramStore.setCompleted();
     return storage as number;
   } catch (error) {
@@ -216,7 +216,7 @@ const getContractMethods = async (): Promise<void> => {
 
   try {
     // Set progress: Getting contract
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
 
     await Tezos.wallet
       .at(CONTRACT_ADDRESS)

--- a/src/modules/tests/tests/counter/counter-contract.ts
+++ b/src/modules/tests/tests/counter/counter-contract.ts
@@ -64,7 +64,7 @@ const increment = async (amount: number): Promise<number | undefined> => {
 
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
     return await getContractStorage(true);
   } catch (error) {
     console.log(`Error: ${JSON.stringify(error, null, 2)}`);
@@ -118,7 +118,7 @@ const decrement = async (amount: number): Promise<number | undefined> => {
     const confirmation = await operation.confirmation(3);
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
     return await getContractStorage(true);
   } catch (error) {
     console.log(`Error: ${JSON.stringify(error, null, 2)}`);
@@ -164,7 +164,7 @@ const reset = async (): Promise<void> => {
     const confirmation = await operation.confirmation(3);
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.log(`Error: ${JSON.stringify(error, null, 2)}`);
     diagramStore.setErrorMessage(error, TEST_ID);
@@ -196,7 +196,7 @@ const getContractStorage = async (
     console.log(`Current storage value: ${storage}`);
     if (!noDiagram)
       diagramStore.setProgress("read-storage", "running", TEST_ID);
-    if (!noDiagram) diagramStore.setProgress("success", "completed", TEST_ID);
+    if (!noDiagram) diagramStore.setCompleted(TEST_ID);
     return storage as number;
   } catch (error) {
     console.log(`Error: ${error}`);
@@ -225,7 +225,7 @@ const getContractMethods = async (): Promise<void> => {
       .then((c) => {
         const methods = c.parameterSchema.ExtractSignatures();
         console.log(JSON.stringify(methods, null, 2));
-        diagramStore.setProgress("success", "completed", TEST_ID);
+        diagramStore.setCompleted(TEST_ID);
       })
       .catch((error) => {
         console.log(`Error: ${error}`);

--- a/src/modules/tests/tests/counter/counter-contract.ts
+++ b/src/modules/tests/tests/counter/counter-contract.ts
@@ -36,12 +36,12 @@ const increment = async (amount: number): Promise<number | undefined> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
 
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
     console.log(`Incrementing storage value by ${amount}...`);
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     const transferParams = await contract.methodsObject
       .increment(amount)
       .toTransferParams();
@@ -55,20 +55,20 @@ const increment = async (amount: number): Promise<number | undefined> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running", TEST_ID);
+    diagramStore.setProgress("execute-operation", "running");
 
     const operation = await contract.methodsObject.increment(amount).send();
 
-    diagramStore.setProgress("wait-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-confirmation", "running");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash)
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
-    diagramStore.setCompleted(TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
+    diagramStore.setCompleted();
     return await getContractStorage(true);
   } catch (error) {
     console.log(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 
@@ -95,10 +95,10 @@ const decrement = async (amount: number): Promise<number | undefined> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     const transferParams = await contract.methodsObject
       .decrement(amount)
       .toTransferParams();
@@ -112,17 +112,17 @@ const decrement = async (amount: number): Promise<number | undefined> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running", TEST_ID);
+    diagramStore.setProgress("execute-operation", "running");
     const operation = await contract.methodsObject.decrement(amount).send();
-    diagramStore.setProgress("wait-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-confirmation", "running");
     const confirmation = await operation.confirmation(3);
     if (confirmation?.block.hash)
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
-    diagramStore.setCompleted(TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
+    diagramStore.setCompleted();
     return await getContractStorage(true);
   } catch (error) {
     console.log(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 
@@ -141,10 +141,10 @@ const reset = async (): Promise<void> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     const transferParams = await contract.methodsObject
       .reset()
       .toTransferParams();
@@ -158,16 +158,16 @@ const reset = async (): Promise<void> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running", TEST_ID);
+    diagramStore.setProgress("execute-operation", "running");
     const operation = await contract.methodsObject.reset().send();
-    diagramStore.setProgress("wait-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-confirmation", "running");
     const confirmation = await operation.confirmation(3);
     if (confirmation?.block.hash)
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
-    diagramStore.setCompleted(TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
+    diagramStore.setCompleted();
   } catch (error) {
     console.log(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 
@@ -188,19 +188,17 @@ const getContractStorage = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    if (!noDiagram)
-      diagramStore.setProgress("get-contract", "running", TEST_ID);
+    if (!noDiagram) diagramStore.setProgress("get-contract", "running");
 
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
     const storage = await contract.storage();
     console.log(`Current storage value: ${storage}`);
-    if (!noDiagram)
-      diagramStore.setProgress("read-storage", "running", TEST_ID);
-    if (!noDiagram) diagramStore.setCompleted(TEST_ID);
+    if (!noDiagram) diagramStore.setProgress("read-storage", "running");
+    if (!noDiagram) diagramStore.setCompleted();
     return storage as number;
   } catch (error) {
     console.log(`Error: ${error}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 
@@ -218,21 +216,21 @@ const getContractMethods = async (): Promise<void> => {
 
   try {
     // Set progress: Getting contract
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
 
     await Tezos.wallet
       .at(CONTRACT_ADDRESS)
       .then((c) => {
         const methods = c.parameterSchema.ExtractSignatures();
         console.log(JSON.stringify(methods, null, 2));
-        diagramStore.setCompleted(TEST_ID);
+        diagramStore.setCompleted();
       })
       .catch((error) => {
         console.log(`Error: ${error}`);
       });
   } catch (error) {
     console.log(`Error: ${error}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 
   return;

--- a/src/modules/tests/tests/delegation/delegation.ts
+++ b/src/modules/tests/tests/delegation/delegation.ts
@@ -46,7 +46,7 @@ const delegate = async (address: string) => {
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(`Failed to delegate to '${address}': ${error}`);
     diagramStore.setErrorMessage(error, TEST_ID);
@@ -88,7 +88,7 @@ const undelegate = async () => {
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(`Failed to undelegate: ${error}`);
     diagramStore.setErrorMessage(error, TEST_ID);

--- a/src/modules/tests/tests/delegation/delegation.ts
+++ b/src/modules/tests/tests/delegation/delegation.ts
@@ -20,7 +20,7 @@ const delegate = async (address: string) => {
     if (!walletStore.getAddress)
       throw new Error("No address found to delegate from");
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     estimate = await Tezos.estimate.setDelegate({
       source: walletStore.getAddress,
       delegate: address,
@@ -34,22 +34,22 @@ const delegate = async (address: string) => {
       });
     }
 
-    diagramStore.setProgress("set-delegate", "running", TEST_ID);
-    diagramStore.setProgress("wait-for-user", "running", TEST_ID);
+    diagramStore.setProgress("set-delegate", "running");
+    diagramStore.setProgress("wait-for-user", "running");
     const delegation = await Tezos.wallet
       .setDelegate({ delegate: address })
       .send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-chain-confirmation", "running");
     const confirmation = await delegation.confirmation();
 
     if (confirmation?.block.hash)
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(`Failed to delegate to '${address}': ${error}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     throw error;
   }
 };
@@ -65,7 +65,7 @@ const undelegate = async () => {
     if (!walletStore.getAddress)
       throw new Error("No address found remove delegation for");
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     estimate = await Tezos.estimate.setDelegate({
       source: walletStore.getAddress,
     });
@@ -78,20 +78,20 @@ const undelegate = async () => {
       });
     }
 
-    diagramStore.setProgress("remove-delegation", "running", TEST_ID);
-    diagramStore.setProgress("wait-for-user", "running", TEST_ID);
+    diagramStore.setProgress("remove-delegation", "running");
+    diagramStore.setProgress("wait-for-user", "running");
     const delegation = await Tezos.wallet.setDelegate({}).send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-chain-confirmation", "running");
     const confirmation = await delegation.confirmation();
 
     if (confirmation?.block.hash)
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(`Failed to undelegate: ${error}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     throw error;
   }
 };

--- a/src/modules/tests/tests/delegation/delegation.ts
+++ b/src/modules/tests/tests/delegation/delegation.ts
@@ -20,7 +20,7 @@ const delegate = async (address: string) => {
     if (!walletStore.getAddress)
       throw new Error("No address found to delegate from");
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     estimate = await Tezos.estimate.setDelegate({
       source: walletStore.getAddress,
       delegate: address,
@@ -34,13 +34,13 @@ const delegate = async (address: string) => {
       });
     }
 
-    diagramStore.setProgress("set-delegate", "running");
-    diagramStore.setProgress("wait-for-user", "running");
+    diagramStore.setProgress("set-delegate");
+    diagramStore.setProgress("wait-for-user");
     const delegation = await Tezos.wallet
       .setDelegate({ delegate: address })
       .send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running");
+    diagramStore.setProgress("wait-for-chain-confirmation");
     const confirmation = await delegation.confirmation();
 
     if (confirmation?.block.hash)
@@ -65,7 +65,7 @@ const undelegate = async () => {
     if (!walletStore.getAddress)
       throw new Error("No address found remove delegation for");
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     estimate = await Tezos.estimate.setDelegate({
       source: walletStore.getAddress,
     });
@@ -78,11 +78,11 @@ const undelegate = async () => {
       });
     }
 
-    diagramStore.setProgress("remove-delegation", "running");
-    diagramStore.setProgress("wait-for-user", "running");
+    diagramStore.setProgress("remove-delegation");
+    diagramStore.setProgress("wait-for-user");
     const delegation = await Tezos.wallet.setDelegate({}).send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running");
+    diagramStore.setProgress("wait-for-chain-confirmation");
     const confirmation = await delegation.confirmation();
 
     if (confirmation?.block.hash)

--- a/src/modules/tests/tests/estimate-fees/estimate-fees.ts
+++ b/src/modules/tests/tests/estimate-fees/estimate-fees.ts
@@ -13,7 +13,7 @@ const estimateFees = async () => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     estimate = await Tezos.estimate.transfer({ to: address, amount: 1 });
 
     if (estimate) {

--- a/src/modules/tests/tests/estimate-fees/estimate-fees.ts
+++ b/src/modules/tests/tests/estimate-fees/estimate-fees.ts
@@ -25,7 +25,7 @@ const estimateFees = async () => {
       });
     }
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(
       `Failed to estiimate fees for transfer to '${address}': ${error}`,

--- a/src/modules/tests/tests/estimate-fees/estimate-fees.ts
+++ b/src/modules/tests/tests/estimate-fees/estimate-fees.ts
@@ -3,7 +3,6 @@ import { useWalletStore } from "@/stores/walletStore";
 import type { Estimate } from "@taquito/taquito";
 import { PiggyBank } from "lucide-vue-next";
 
-const TEST_ID = "estimate-fees";
 const address = "tz1VRj54TQDtUGgv6gF4AbGbXMphyDpVkCpf";
 
 let estimate: Estimate;
@@ -14,7 +13,7 @@ const estimateFees = async () => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     estimate = await Tezos.estimate.transfer({ to: address, amount: 1 });
 
     if (estimate) {
@@ -25,12 +24,12 @@ const estimateFees = async () => {
       });
     }
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(
       `Failed to estiimate fees for transfer to '${address}': ${error}`,
     );
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     throw error;
   }
 };

--- a/src/modules/tests/tests/fa2-token/fa2-token.ts
+++ b/src/modules/tests/tests/fa2-token/fa2-token.ts
@@ -66,11 +66,11 @@ export const mintTokens = async (param: MintParam): Promise<void> => {
 
   try {
     diagramStore.setTestDiagram(TEST_ID, "mint");
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
 
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     const transferParams = await contract.methodsObject
       .mint(param)
       .toTransferParams();
@@ -84,10 +84,10 @@ export const mintTokens = async (param: MintParam): Promise<void> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running");
+    diagramStore.setProgress("execute-operation");
     const operation = await contract.methodsObject.mint(param).send();
 
-    diagramStore.setProgress("wait-confirmation", "running");
+    diagramStore.setProgress("wait-confirmation");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
@@ -113,11 +113,11 @@ export const burnTokens = async (param: BurnParam): Promise<void> => {
 
   try {
     diagramStore.setTestDiagram(TEST_ID, "burn");
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
 
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     const transferParams = await contract.methodsObject
       .burn(param)
       .toTransferParams();
@@ -131,10 +131,10 @@ export const burnTokens = async (param: BurnParam): Promise<void> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running");
+    diagramStore.setProgress("execute-operation");
     const operation = await contract.methodsObject.burn(param).send();
 
-    diagramStore.setProgress("wait-confirmation", "running");
+    diagramStore.setProgress("wait-confirmation");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
@@ -162,7 +162,7 @@ export const transferTokens = async (
 
   try {
     diagramStore.setTestDiagram(TEST_ID, "transfer");
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
 
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
@@ -170,7 +170,7 @@ export const transferTokens = async (
       throw new Error("No transfer parameters provided");
     }
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     const transferParams = await contract.methodsObject
       .transfer(transfers)
       .toTransferParams();
@@ -184,10 +184,10 @@ export const transferTokens = async (
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running");
+    diagramStore.setProgress("execute-operation");
     const operation = await contract.methodsObject.transfer(transfers).send();
 
-    diagramStore.setProgress("wait-confirmation", "running");
+    diagramStore.setProgress("wait-confirmation");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
@@ -217,11 +217,11 @@ export const getTokenBalancesDirect = async (
 
   try {
     diagramStore.setTestDiagram(TEST_ID, "get-balance");
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
 
     const fa2Contract = await Tezos.contract.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("read-fa2-storage", "running");
+    diagramStore.setProgress("read-fa2-storage");
     const storage = (await fa2Contract.storage()) as FA2TokenStorage;
 
     const balances: TokenBalance[] = [];
@@ -270,12 +270,12 @@ export const getTokenBalancesWithCallback = async (
 
   try {
     diagramStore.setTestDiagram(TEST_ID, "get-balance-with-callback");
-    diagramStore.setProgress("get-contracts", "running");
+    diagramStore.setProgress("get-contracts");
 
     const fa2Contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
     const callbackContract = await Tezos.wallet.at(CALLBACK_CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("call-balance-of", "running");
+    diagramStore.setProgress("call-balance-of");
 
     const balanceOfParams = {
       requests: requests,
@@ -286,14 +286,14 @@ export const getTokenBalancesWithCallback = async (
       .balance_of(balanceOfParams)
       .send();
 
-    diagramStore.setProgress("wait-confirmation", "running");
+    diagramStore.setProgress("wait-confirmation");
     const confirmation = await operation.confirmation(1);
 
     if (confirmation?.block.hash) {
       diagramStore.setOperationHash(confirmation?.block.hash);
     }
 
-    diagramStore.setProgress("read-callback-storage", "running");
+    diagramStore.setProgress("read-callback-storage");
     const callbackStorage =
       (await callbackContract.storage()) as BalanceCallbackStorage;
 

--- a/src/modules/tests/tests/fa2-token/fa2-token.ts
+++ b/src/modules/tests/tests/fa2-token/fa2-token.ts
@@ -93,7 +93,7 @@ export const mintTokens = async (param: MintParam): Promise<void> => {
     if (confirmation?.block.hash) {
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
     }
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
     diagramStore.setErrorMessage(error, TEST_ID);
@@ -140,7 +140,7 @@ export const burnTokens = async (param: BurnParam): Promise<void> => {
     if (confirmation?.block.hash) {
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
     }
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
     diagramStore.setErrorMessage(error, TEST_ID);
@@ -193,7 +193,7 @@ export const transferTokens = async (
     if (confirmation?.block.hash) {
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
     }
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
     diagramStore.setErrorMessage(error, TEST_ID);
@@ -245,7 +245,7 @@ export const getTokenBalancesDirect = async (
       });
     }
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
     return balances;
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
@@ -312,7 +312,7 @@ export const getTokenBalancesWithCallback = async (
       balance: response.balance,
     }));
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
     return balances;
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);

--- a/src/modules/tests/tests/fa2-token/fa2-token.ts
+++ b/src/modules/tests/tests/fa2-token/fa2-token.ts
@@ -66,11 +66,11 @@ export const mintTokens = async (param: MintParam): Promise<void> => {
 
   try {
     diagramStore.setTestDiagram(TEST_ID, "mint");
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
 
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     const transferParams = await contract.methodsObject
       .mint(param)
       .toTransferParams();
@@ -84,19 +84,19 @@ export const mintTokens = async (param: MintParam): Promise<void> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running", TEST_ID);
+    diagramStore.setProgress("execute-operation", "running");
     const operation = await contract.methodsObject.mint(param).send();
 
-    diagramStore.setProgress("wait-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-confirmation", "running");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
     }
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 
@@ -113,11 +113,11 @@ export const burnTokens = async (param: BurnParam): Promise<void> => {
 
   try {
     diagramStore.setTestDiagram(TEST_ID, "burn");
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
 
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     const transferParams = await contract.methodsObject
       .burn(param)
       .toTransferParams();
@@ -131,19 +131,19 @@ export const burnTokens = async (param: BurnParam): Promise<void> => {
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running", TEST_ID);
+    diagramStore.setProgress("execute-operation", "running");
     const operation = await contract.methodsObject.burn(param).send();
 
-    diagramStore.setProgress("wait-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-confirmation", "running");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
     }
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 
@@ -162,7 +162,7 @@ export const transferTokens = async (
 
   try {
     diagramStore.setTestDiagram(TEST_ID, "transfer");
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
 
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
@@ -170,7 +170,7 @@ export const transferTokens = async (
       throw new Error("No transfer parameters provided");
     }
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     const transferParams = await contract.methodsObject
       .transfer(transfers)
       .toTransferParams();
@@ -184,19 +184,19 @@ export const transferTokens = async (
       });
     }
 
-    diagramStore.setProgress("execute-operation", "running", TEST_ID);
+    diagramStore.setProgress("execute-operation", "running");
     const operation = await contract.methodsObject.transfer(transfers).send();
 
-    diagramStore.setProgress("wait-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-confirmation", "running");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash) {
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
     }
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 
@@ -217,11 +217,11 @@ export const getTokenBalancesDirect = async (
 
   try {
     diagramStore.setTestDiagram(TEST_ID, "get-balance");
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
 
     const fa2Contract = await Tezos.contract.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("read-fa2-storage", "running", TEST_ID);
+    diagramStore.setProgress("read-fa2-storage", "running");
     const storage = (await fa2Contract.storage()) as FA2TokenStorage;
 
     const balances: TokenBalance[] = [];
@@ -245,11 +245,11 @@ export const getTokenBalancesDirect = async (
       });
     }
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
     return balances;
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     return [];
   }
 };
@@ -270,12 +270,12 @@ export const getTokenBalancesWithCallback = async (
 
   try {
     diagramStore.setTestDiagram(TEST_ID, "get-balance-with-callback");
-    diagramStore.setProgress("get-contracts", "running", TEST_ID);
+    diagramStore.setProgress("get-contracts", "running");
 
     const fa2Contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
     const callbackContract = await Tezos.wallet.at(CALLBACK_CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("call-balance-of", "running", TEST_ID);
+    diagramStore.setProgress("call-balance-of", "running");
 
     const balanceOfParams = {
       requests: requests,
@@ -286,14 +286,14 @@ export const getTokenBalancesWithCallback = async (
       .balance_of(balanceOfParams)
       .send();
 
-    diagramStore.setProgress("wait-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-confirmation", "running");
     const confirmation = await operation.confirmation(1);
 
     if (confirmation?.block.hash) {
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
     }
 
-    diagramStore.setProgress("read-callback-storage", "running", TEST_ID);
+    diagramStore.setProgress("read-callback-storage", "running");
     const callbackStorage =
       (await callbackContract.storage()) as BalanceCallbackStorage;
 
@@ -312,11 +312,11 @@ export const getTokenBalancesWithCallback = async (
       balance: response.balance,
     }));
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
     return balances;
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     return [];
   }
 };

--- a/src/modules/tests/tests/failing-contract/failing-contract.ts
+++ b/src/modules/tests/tests/failing-contract/failing-contract.ts
@@ -7,7 +7,6 @@ const CONTRACT_ADDRESS =
   (contracts as ContractConfig[]).find(
     (contract: ContractConfig) => contract.contractName === "counter",
   )?.address ?? "";
-const TEST_ID = "failing-contract";
 
 /**
  * Attempts to call a contract with invalid parameters to test error handling.
@@ -23,10 +22,10 @@ const testContractFailure = async (scenario: string): Promise<void> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("execute-operation", "running", TEST_ID);
+    diagramStore.setProgress("execute-operation", "running");
     switch (scenario) {
       case "wrong-type":
         // Try to pass a string instead of a number to increment
@@ -55,7 +54,7 @@ const testContractFailure = async (scenario: string): Promise<void> => {
       `Expected contract call failure for scenario '${scenario}':`,
       JSON.stringify(error, null, 2),
     );
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 

--- a/src/modules/tests/tests/failing-contract/failing-contract.ts
+++ b/src/modules/tests/tests/failing-contract/failing-contract.ts
@@ -22,10 +22,10 @@ const testContractFailure = async (scenario: string): Promise<void> => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("execute-operation", "running");
+    diagramStore.setProgress("execute-operation");
     switch (scenario) {
       case "wrong-type":
         // Try to pass a string instead of a number to increment

--- a/src/modules/tests/tests/failing-noop/failing-noop.ts
+++ b/src/modules/tests/tests/failing-noop/failing-noop.ts
@@ -2,8 +2,6 @@ import { useDiagramStore } from "@/stores/diagramStore";
 import { useWalletStore } from "@/stores/walletStore";
 import { verifySignature } from "@taquito/utils";
 
-const TEST_ID = "failing-noop";
-
 /**
  * Signs a failing noop operation and verifies the signature.
  *
@@ -20,18 +18,18 @@ const failNoop = async (): Promise<void> => {
   const hex = "48656C6C6F20576F726C64";
 
   try {
-    diagramStore.setProgress("signing-operation", "running", TEST_ID);
-    diagramStore.setProgress("wait-for-user", "running", TEST_ID);
+    diagramStore.setProgress("signing-operation", "running");
+    diagramStore.setProgress("wait-for-user", "running");
     const signed = await Tezos.wallet.signFailingNoop({
       arbitrary: hex,
       basedOnBlock: "head",
     });
 
-    diagramStore.setProgress("get-public-key", "running", TEST_ID);
+    diagramStore.setProgress("get-public-key", "running");
     const pk = await walletStore.getWalletPublicKey();
     if (!pk) throw new Error("No public key found");
 
-    diagramStore.setProgress("verify-signature", "running", TEST_ID);
+    diagramStore.setProgress("verify-signature", "running");
     await verifySignature(
       signed.bytes,
       pk,
@@ -39,10 +37,10 @@ const failNoop = async (): Promise<void> => {
       new Uint8Array([3]),
     );
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.log(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 

--- a/src/modules/tests/tests/failing-noop/failing-noop.ts
+++ b/src/modules/tests/tests/failing-noop/failing-noop.ts
@@ -39,7 +39,7 @@ const failNoop = async (): Promise<void> => {
       new Uint8Array([3]),
     );
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.log(`Error: ${JSON.stringify(error, null, 2)}`);
     diagramStore.setErrorMessage(error, TEST_ID);

--- a/src/modules/tests/tests/failing-noop/failing-noop.ts
+++ b/src/modules/tests/tests/failing-noop/failing-noop.ts
@@ -18,18 +18,18 @@ const failNoop = async (): Promise<void> => {
   const hex = "48656C6C6F20576F726C64";
 
   try {
-    diagramStore.setProgress("signing-operation", "running");
-    diagramStore.setProgress("wait-for-user", "running");
+    diagramStore.setProgress("signing-operation");
+    diagramStore.setProgress("wait-for-user");
     const signed = await Tezos.wallet.signFailingNoop({
       arbitrary: hex,
       basedOnBlock: "head",
     });
 
-    diagramStore.setProgress("get-public-key", "running");
+    diagramStore.setProgress("get-public-key");
     const pk = await walletStore.getWalletPublicKey();
     if (!pk) throw new Error("No public key found");
 
-    diagramStore.setProgress("verify-signature", "running");
+    diagramStore.setProgress("verify-signature");
     await verifySignature(
       signed.bytes,
       pk,

--- a/src/modules/tests/tests/global-constants/global-constants.ts
+++ b/src/modules/tests/tests/global-constants/global-constants.ts
@@ -4,8 +4,6 @@ import { useWalletStore } from "@/stores/walletStore";
 import type { Estimate } from "@taquito/taquito";
 import { PiggyBank } from "lucide-vue-next";
 
-const TEST_ID = "global-constants";
-
 let estimate: Estimate;
 
 /**
@@ -23,7 +21,7 @@ const registerGlobalConstant = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     estimate = await Tezos.estimate.registerGlobalConstant({ value });
 
     if (estimate) {
@@ -34,22 +32,22 @@ const registerGlobalConstant = async (
       });
     }
 
-    diagramStore.setProgress("register-constant", "running", TEST_ID);
+    diagramStore.setProgress("register-constant", "running");
     const operation = await Tezos.contract.registerGlobalConstant({ value });
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-chain-confirmation", "running");
     const confirmation = await operation.confirmation(3);
 
     const opHash = getOperationHash(confirmation);
     if (opHash) {
-      diagramStore.setOperationHash(opHash, TEST_ID);
+      diagramStore.setOperationHash(opHash);
     }
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
     return operation.globalConstantHash;
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     throw error;
   }
 };

--- a/src/modules/tests/tests/global-constants/global-constants.ts
+++ b/src/modules/tests/tests/global-constants/global-constants.ts
@@ -45,7 +45,7 @@ const registerGlobalConstant = async (
       diagramStore.setOperationHash(opHash, TEST_ID);
     }
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
     return operation.globalConstantHash;
   } catch (error) {
     console.error(`Error: ${JSON.stringify(error, null, 2)}`);

--- a/src/modules/tests/tests/global-constants/global-constants.ts
+++ b/src/modules/tests/tests/global-constants/global-constants.ts
@@ -21,7 +21,7 @@ const registerGlobalConstant = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     estimate = await Tezos.estimate.registerGlobalConstant({ value });
 
     if (estimate) {
@@ -32,10 +32,10 @@ const registerGlobalConstant = async (
       });
     }
 
-    diagramStore.setProgress("register-constant", "running");
+    diagramStore.setProgress("register-constant");
     const operation = await Tezos.contract.registerGlobalConstant({ value });
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running");
+    diagramStore.setProgress("wait-for-chain-confirmation");
     const confirmation = await operation.confirmation(3);
 
     const opHash = getOperationHash(confirmation);

--- a/src/modules/tests/tests/increase-paid-storage/increase-paid-storage.ts
+++ b/src/modules/tests/tests/increase-paid-storage/increase-paid-storage.ts
@@ -15,26 +15,26 @@ const increaseStorage = async (contract: string, bytes: number) => {
     }
 
     diagramStore.setTestDiagram(TEST_ID, "increase");
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    diagramStore.setProgress("wait-for-user", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-user", "running");
     const operation = await Tezos.wallet
       .increasePaidStorage({ amount: bytes, destination: contract })
       .send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-chain-confirmation", "running");
     const confirmation = await operation.confirmation(3);
     if (confirmation?.block.hash)
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(
       `Failed to increase paid storage on contract '${contract}': ${error}`,
     );
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     throw error;
   }
 };

--- a/src/modules/tests/tests/increase-paid-storage/increase-paid-storage.ts
+++ b/src/modules/tests/tests/increase-paid-storage/increase-paid-storage.ts
@@ -15,16 +15,16 @@ const increaseStorage = async (contract: string, bytes: number) => {
     }
 
     diagramStore.setTestDiagram(TEST_ID, "increase");
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
 
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
-    diagramStore.setProgress("wait-for-user", "running");
+    diagramStore.setProgress("wait-for-user");
     const operation = await Tezos.wallet
       .increasePaidStorage({ amount: bytes, destination: contract })
       .send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running");
+    diagramStore.setProgress("wait-for-chain-confirmation");
     const confirmation = await operation.confirmation(3);
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash);

--- a/src/modules/tests/tests/increase-paid-storage/increase-paid-storage.ts
+++ b/src/modules/tests/tests/increase-paid-storage/increase-paid-storage.ts
@@ -29,7 +29,7 @@ const increaseStorage = async (contract: string, bytes: number) => {
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(
       `Failed to increase paid storage on contract '${contract}': ${error}`,

--- a/src/modules/tests/tests/sign-payload/sign-payload.ts
+++ b/src/modules/tests/tests/sign-payload/sign-payload.ts
@@ -34,10 +34,10 @@ const sign = async (
       loadBeaconTypes(),
     ]);
 
-    diagramStore.setProgress("join-payload", "running", TEST_ID);
+    diagramStore.setProgress("join-payload", "running");
     const formattedInput: string = ["Tezos Signed Message:", input].join(" ");
 
-    diagramStore.setProgress("convert-to-bytes", "running", TEST_ID);
+    diagramStore.setProgress("convert-to-bytes", "running");
     const bytes = alreadyBytes ? input : utils.stringToBytes(formattedInput);
     const bytesLength = (bytes.length / 2).toString(16);
     const addPadding = `00000000${bytesLength}`;
@@ -57,8 +57,8 @@ const sign = async (
       throw new Error("No wallet found");
     }
 
-    diagramStore.setProgress("request-wallet-sign", "running", TEST_ID);
-    diagramStore.setProgress("wait-for-user", "running", TEST_ID);
+    diagramStore.setProgress("request-wallet-sign", "running");
+    diagramStore.setProgress("wait-for-user", "running");
 
     // Dynamic wallet type checking and signing
     let signedPayload: { signature: string };
@@ -79,7 +79,7 @@ const sign = async (
 
     const { signature } = signedPayload;
 
-    diagramStore.setProgress("verify-signature", "running", TEST_ID);
+    diagramStore.setProgress("verify-signature", "running");
     const publicKey = await walletStore.getWalletPublicKey();
     if (!publicKey) {
       throw new Error("No public key found");
@@ -95,13 +95,13 @@ const sign = async (
     }
 
     if (!noDiagram) {
-      diagramStore.setCompleted(TEST_ID);
+      diagramStore.setCompleted();
     }
 
     return signature;
   } catch (error) {
     console.error(`Failed to sign payload: ${error}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     return null;
   }
 };
@@ -157,8 +157,8 @@ const signTzip32 = async (input: string) => {
       throw new Error("No wallet found");
     }
 
-    diagramStore.setProgress("request-wallet-sign", "running", TEST_ID);
-    diagramStore.setProgress("wait-for-user", "running", TEST_ID);
+    diagramStore.setProgress("request-wallet-sign", "running");
+    diagramStore.setProgress("wait-for-user", "running");
 
     // Dynamic wallet type checking and signing
     let signedPayload: { signature: string };
@@ -178,12 +178,12 @@ const signTzip32 = async (input: string) => {
     }
 
     const { signature } = signedPayload;
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
 
     return signature;
   } catch (error) {
     console.error(`Failed to sign payload: ${error}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     return null;
   }
 };
@@ -199,7 +199,7 @@ export const signMichelsonData = async (
   // Load michel-codec only when needed for Michelson signing
   const michelCodec = await loadMichelCodec();
 
-  diagramStore.setProgress("parse-micheline-expression", "running", TEST_ID);
+  diagramStore.setProgress("parse-micheline-expression", "running");
   const p = new michelCodec.Parser();
   const dataJSON = p.parseMichelineExpression(data);
   const typeJSON = p.parseMichelineExpression(type);
@@ -208,7 +208,7 @@ export const signMichelsonData = async (
     throw new Error("Failed to parse Micheline expression");
   }
 
-  diagramStore.setProgress("pack-data-bytes", "running", TEST_ID);
+  diagramStore.setProgress("pack-data-bytes", "running");
   // Type assertion is necessary here because parseMichelineExpression returns Expr
   // but packDataBytes expects more specific Micheline types. This is safe since we're parsing valid Micheline.
   const packed = michelCodec.packDataBytes(
@@ -221,7 +221,7 @@ export const signMichelsonData = async (
     throw new Error("Failed to sign Michelson data");
   }
 
-  diagramStore.setCompleted(TEST_ID);
+  diagramStore.setCompleted();
   return signature;
 };
 
@@ -253,8 +253,8 @@ const verifyPayloadViaContract = async (
       const characterEncoding = "0";
       const message = payload;
 
-      diagramStore.setProgress("join-payload", "running", TEST_ID);
-      diagramStore.setProgress("convert-to-bytes", "running", TEST_ID);
+      diagramStore.setProgress("join-payload", "running");
+      diagramStore.setProgress("convert-to-bytes", "running");
 
       // For TZIP-32 verification, we need to construct the same Micheline-wrapped payload
       // that was used for signing: "05" + "01" + fullPayloadHex
@@ -276,12 +276,12 @@ const verifyPayloadViaContract = async (
         messageHex;
       payloadBytes = "05" + "01" + fullPayloadHex;
     } else {
-      diagramStore.setProgress("join-payload", "running", TEST_ID);
+      diagramStore.setProgress("join-payload", "running");
       const formattedInput: string = ["Tezos Signed Message:", payload].join(
         " ",
       );
 
-      diagramStore.setProgress("convert-to-bytes", "running", TEST_ID);
+      diagramStore.setProgress("convert-to-bytes", "running");
       const bytes = utils.stringToBytes(formattedInput);
       const bytesLength = (bytes.length / 2).toString(16);
       const addPadding = `00000000${bytesLength}`;
@@ -289,10 +289,10 @@ const verifyPayloadViaContract = async (
       payloadBytes = "05" + "01" + paddedBytesLength + bytes;
     }
 
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
     const contract = await Tezos.wallet.at(SIGNATURE_CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     const parameter = {
       public_key: publicKey,
       signature: signature,
@@ -313,18 +313,18 @@ const verifyPayloadViaContract = async (
       });
     }
 
-    diagramStore.setProgress("wait-for-user", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-user", "running");
     const operation = await contract.methodsObject.default(parameter).send();
 
-    diagramStore.setProgress("wait-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-confirmation", "running");
     const confirmation = await operation.confirmation(1);
     if (confirmation?.block.hash)
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
-    diagramStore.setCompleted(TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
+    diagramStore.setCompleted();
     return true;
   } catch (error) {
     console.error(`Failed to verify payload via contract: ${error}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     return false;
   }
 };

--- a/src/modules/tests/tests/sign-payload/sign-payload.ts
+++ b/src/modules/tests/tests/sign-payload/sign-payload.ts
@@ -95,7 +95,7 @@ const sign = async (
     }
 
     if (!noDiagram) {
-      diagramStore.setProgress("success", "completed", TEST_ID);
+      diagramStore.setCompleted(TEST_ID);
     }
 
     return signature;
@@ -178,7 +178,7 @@ const signTzip32 = async (input: string) => {
     }
 
     const { signature } = signedPayload;
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
 
     return signature;
   } catch (error) {
@@ -221,7 +221,7 @@ export const signMichelsonData = async (
     throw new Error("Failed to sign Michelson data");
   }
 
-  diagramStore.setProgress("success", "completed", TEST_ID);
+  diagramStore.setCompleted(TEST_ID);
   return signature;
 };
 
@@ -320,7 +320,7 @@ const verifyPayloadViaContract = async (
     const confirmation = await operation.confirmation(1);
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
     return true;
   } catch (error) {
     console.error(`Failed to verify payload via contract: ${error}`);

--- a/src/modules/tests/tests/sign-payload/sign-payload.ts
+++ b/src/modules/tests/tests/sign-payload/sign-payload.ts
@@ -34,10 +34,10 @@ const sign = async (
       loadBeaconTypes(),
     ]);
 
-    diagramStore.setProgress("join-payload", "running");
+    diagramStore.setProgress("join-payload");
     const formattedInput: string = ["Tezos Signed Message:", input].join(" ");
 
-    diagramStore.setProgress("convert-to-bytes", "running");
+    diagramStore.setProgress("convert-to-bytes");
     const bytes = alreadyBytes ? input : utils.stringToBytes(formattedInput);
     const bytesLength = (bytes.length / 2).toString(16);
     const addPadding = `00000000${bytesLength}`;
@@ -57,8 +57,8 @@ const sign = async (
       throw new Error("No wallet found");
     }
 
-    diagramStore.setProgress("request-wallet-sign", "running");
-    diagramStore.setProgress("wait-for-user", "running");
+    diagramStore.setProgress("request-wallet-sign");
+    diagramStore.setProgress("wait-for-user");
 
     // Dynamic wallet type checking and signing
     let signedPayload: { signature: string };
@@ -79,7 +79,7 @@ const sign = async (
 
     const { signature } = signedPayload;
 
-    diagramStore.setProgress("verify-signature", "running");
+    diagramStore.setProgress("verify-signature");
     const publicKey = await walletStore.getWalletPublicKey();
     if (!publicKey) {
       throw new Error("No public key found");
@@ -157,8 +157,8 @@ const signTzip32 = async (input: string) => {
       throw new Error("No wallet found");
     }
 
-    diagramStore.setProgress("request-wallet-sign", "running");
-    diagramStore.setProgress("wait-for-user", "running");
+    diagramStore.setProgress("request-wallet-sign");
+    diagramStore.setProgress("wait-for-user");
 
     // Dynamic wallet type checking and signing
     let signedPayload: { signature: string };
@@ -199,7 +199,7 @@ export const signMichelsonData = async (
   // Load michel-codec only when needed for Michelson signing
   const michelCodec = await loadMichelCodec();
 
-  diagramStore.setProgress("parse-micheline-expression", "running");
+  diagramStore.setProgress("parse-micheline-expression");
   const p = new michelCodec.Parser();
   const dataJSON = p.parseMichelineExpression(data);
   const typeJSON = p.parseMichelineExpression(type);
@@ -208,7 +208,7 @@ export const signMichelsonData = async (
     throw new Error("Failed to parse Micheline expression");
   }
 
-  diagramStore.setProgress("pack-data-bytes", "running");
+  diagramStore.setProgress("pack-data-bytes");
   // Type assertion is necessary here because parseMichelineExpression returns Expr
   // but packDataBytes expects more specific Micheline types. This is safe since we're parsing valid Micheline.
   const packed = michelCodec.packDataBytes(
@@ -253,8 +253,8 @@ const verifyPayloadViaContract = async (
       const characterEncoding = "0";
       const message = payload;
 
-      diagramStore.setProgress("join-payload", "running");
-      diagramStore.setProgress("convert-to-bytes", "running");
+      diagramStore.setProgress("join-payload");
+      diagramStore.setProgress("convert-to-bytes");
 
       // For TZIP-32 verification, we need to construct the same Micheline-wrapped payload
       // that was used for signing: "05" + "01" + fullPayloadHex
@@ -276,12 +276,12 @@ const verifyPayloadViaContract = async (
         messageHex;
       payloadBytes = "05" + "01" + fullPayloadHex;
     } else {
-      diagramStore.setProgress("join-payload", "running");
+      diagramStore.setProgress("join-payload");
       const formattedInput: string = ["Tezos Signed Message:", payload].join(
         " ",
       );
 
-      diagramStore.setProgress("convert-to-bytes", "running");
+      diagramStore.setProgress("convert-to-bytes");
       const bytes = utils.stringToBytes(formattedInput);
       const bytesLength = (bytes.length / 2).toString(16);
       const addPadding = `00000000${bytesLength}`;
@@ -289,10 +289,10 @@ const verifyPayloadViaContract = async (
       payloadBytes = "05" + "01" + paddedBytesLength + bytes;
     }
 
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
     const contract = await Tezos.wallet.at(SIGNATURE_CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     const parameter = {
       public_key: publicKey,
       signature: signature,
@@ -313,10 +313,10 @@ const verifyPayloadViaContract = async (
       });
     }
 
-    diagramStore.setProgress("wait-for-user", "running");
+    diagramStore.setProgress("wait-for-user");
     const operation = await contract.methodsObject.default(parameter).send();
 
-    diagramStore.setProgress("wait-confirmation", "running");
+    diagramStore.setProgress("wait-confirmation");
     const confirmation = await operation.confirmation(1);
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash);

--- a/src/modules/tests/tests/staking/staking.ts
+++ b/src/modules/tests/tests/staking/staking.ts
@@ -44,7 +44,7 @@ const stake = async (amount: number) => {
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(`Failed to stake '${amount}': ${error}`);
     diagramStore.setErrorMessage(error, TEST_ID);
@@ -88,7 +88,7 @@ const unstake = async (amount: number) => {
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(`Failed to unstake '${amount}': ${error}`);
     diagramStore.setErrorMessage(error, TEST_ID);
@@ -124,7 +124,7 @@ const finalizeUnstake = async () => {
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(`Failed to finalize unstake: ${error}`);
     diagramStore.setErrorMessage(error, TEST_ID);

--- a/src/modules/tests/tests/staking/staking.ts
+++ b/src/modules/tests/tests/staking/staking.ts
@@ -15,7 +15,7 @@ const stake = async (amount: number) => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     estimate = await Tezos.estimate.stake({
       amount,
       mutez: false,
@@ -29,8 +29,8 @@ const stake = async (amount: number) => {
       });
     }
 
-    diagramStore.setProgress("stake", "running");
-    diagramStore.setProgress("wait-for-user", "running");
+    diagramStore.setProgress("stake");
+    diagramStore.setProgress("wait-for-user");
     const op = await Tezos.wallet
       .stake({
         amount,
@@ -38,7 +38,7 @@ const stake = async (amount: number) => {
       })
       .send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running");
+    diagramStore.setProgress("wait-for-chain-confirmation");
     const confirmation = await op.confirmation();
 
     if (confirmation?.block.hash)
@@ -59,7 +59,7 @@ const unstake = async (amount: number) => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     estimate = await Tezos.estimate.unstake({
       amount,
       mutez: false,
@@ -73,8 +73,8 @@ const unstake = async (amount: number) => {
       });
     }
 
-    diagramStore.setProgress("unstake", "running");
-    diagramStore.setProgress("wait-for-user", "running");
+    diagramStore.setProgress("unstake");
+    diagramStore.setProgress("wait-for-user");
     const op = await Tezos.wallet
       .unstake({
         amount,
@@ -82,7 +82,7 @@ const unstake = async (amount: number) => {
       })
       .send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running");
+    diagramStore.setProgress("wait-for-chain-confirmation");
     const confirmation = await op.confirmation();
 
     if (confirmation?.block.hash)
@@ -103,7 +103,7 @@ const finalizeUnstake = async () => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     estimate = await Tezos.estimate.finalizeUnstake({});
 
     if (estimate) {
@@ -114,11 +114,11 @@ const finalizeUnstake = async () => {
       });
     }
 
-    diagramStore.setProgress("finalize-unstake", "running");
-    diagramStore.setProgress("wait-for-user", "running");
+    diagramStore.setProgress("finalize-unstake");
+    diagramStore.setProgress("wait-for-user");
     const op = await Tezos.wallet.finalizeUnstake({}).send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running");
+    diagramStore.setProgress("wait-for-chain-confirmation");
     const confirmation = await op.confirmation();
 
     if (confirmation?.block.hash)

--- a/src/modules/tests/tests/staking/staking.ts
+++ b/src/modules/tests/tests/staking/staking.ts
@@ -15,7 +15,7 @@ const stake = async (amount: number) => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     estimate = await Tezos.estimate.stake({
       amount,
       mutez: false,
@@ -29,8 +29,8 @@ const stake = async (amount: number) => {
       });
     }
 
-    diagramStore.setProgress("stake", "running", TEST_ID);
-    diagramStore.setProgress("wait-for-user", "running", TEST_ID);
+    diagramStore.setProgress("stake", "running");
+    diagramStore.setProgress("wait-for-user", "running");
     const op = await Tezos.wallet
       .stake({
         amount,
@@ -38,16 +38,16 @@ const stake = async (amount: number) => {
       })
       .send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-chain-confirmation", "running");
     const confirmation = await op.confirmation();
 
     if (confirmation?.block.hash)
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(`Failed to stake '${amount}': ${error}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     throw error;
   }
 };
@@ -59,7 +59,7 @@ const unstake = async (amount: number) => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     estimate = await Tezos.estimate.unstake({
       amount,
       mutez: false,
@@ -73,8 +73,8 @@ const unstake = async (amount: number) => {
       });
     }
 
-    diagramStore.setProgress("unstake", "running", TEST_ID);
-    diagramStore.setProgress("wait-for-user", "running", TEST_ID);
+    diagramStore.setProgress("unstake", "running");
+    diagramStore.setProgress("wait-for-user", "running");
     const op = await Tezos.wallet
       .unstake({
         amount,
@@ -82,16 +82,16 @@ const unstake = async (amount: number) => {
       })
       .send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-chain-confirmation", "running");
     const confirmation = await op.confirmation();
 
     if (confirmation?.block.hash)
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(`Failed to unstake '${amount}': ${error}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     throw error;
   }
 };
@@ -103,7 +103,7 @@ const finalizeUnstake = async () => {
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     estimate = await Tezos.estimate.finalizeUnstake({});
 
     if (estimate) {
@@ -114,20 +114,20 @@ const finalizeUnstake = async () => {
       });
     }
 
-    diagramStore.setProgress("finalize-unstake", "running", TEST_ID);
-    diagramStore.setProgress("wait-for-user", "running", TEST_ID);
+    diagramStore.setProgress("finalize-unstake", "running");
+    diagramStore.setProgress("wait-for-user", "running");
     const op = await Tezos.wallet.finalizeUnstake({}).send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-chain-confirmation", "running");
     const confirmation = await op.confirmation();
 
     if (confirmation?.block.hash)
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(`Failed to finalize unstake: ${error}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     throw error;
   }
 };

--- a/src/modules/tests/tests/transaction-limit/transaction-limit.ts
+++ b/src/modules/tests/tests/transaction-limit/transaction-limit.ts
@@ -7,7 +7,6 @@ const CONTRACT_ADDRESS =
   (contracts as ContractConfig[]).find(
     (contract: ContractConfig) => contract.contractName === "counter",
   )?.address ?? "";
-const TEST_ID = "transaction-limit";
 
 /**
  * Interacts with the contract using custom transaction limits.
@@ -30,12 +29,12 @@ const interact = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("set-transaction-limit", "running", TEST_ID);
-    diagramStore.setProgress("execute-operation", "running", TEST_ID);
-    diagramStore.setProgress("wait-for-user", "running", TEST_ID);
+    diagramStore.setProgress("set-transaction-limit", "running");
+    diagramStore.setProgress("execute-operation", "running");
+    diagramStore.setProgress("wait-for-user", "running");
 
     const operation = await contract.methodsObject.increment(1).send({
       storageLimit,
@@ -43,15 +42,15 @@ const interact = async (
       fee,
     });
 
-    diagramStore.setProgress("wait-chain-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-chain-confirmation", "running");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash)
-      diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
-    diagramStore.setCompleted(TEST_ID);
+      diagramStore.setOperationHash(confirmation?.block.hash);
+    diagramStore.setCompleted();
   } catch (error) {
     console.log(`Error: ${JSON.stringify(error, null, 2)}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 

--- a/src/modules/tests/tests/transaction-limit/transaction-limit.ts
+++ b/src/modules/tests/tests/transaction-limit/transaction-limit.ts
@@ -48,7 +48,7 @@ const interact = async (
 
     if (confirmation?.block.hash)
       diagramStore.setOperationHash(confirmation?.block.hash, TEST_ID);
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.log(`Error: ${JSON.stringify(error, null, 2)}`);
     diagramStore.setErrorMessage(error, TEST_ID);

--- a/src/modules/tests/tests/transaction-limit/transaction-limit.ts
+++ b/src/modules/tests/tests/transaction-limit/transaction-limit.ts
@@ -29,12 +29,12 @@ const interact = async (
   const Tezos = walletStore.getTezos;
 
   try {
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
     const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
 
-    diagramStore.setProgress("set-transaction-limit", "running");
-    diagramStore.setProgress("execute-operation", "running");
-    diagramStore.setProgress("wait-for-user", "running");
+    diagramStore.setProgress("set-transaction-limit");
+    diagramStore.setProgress("execute-operation");
+    diagramStore.setProgress("wait-for-user");
 
     const operation = await contract.methodsObject.increment(1).send({
       storageLimit,
@@ -42,7 +42,7 @@ const interact = async (
       fee,
     });
 
-    diagramStore.setProgress("wait-chain-confirmation", "running");
+    diagramStore.setProgress("wait-chain-confirmation");
     const confirmation = await operation.confirmation(3);
 
     if (confirmation?.block.hash)

--- a/src/modules/tests/tests/transfer/transfer-tez.ts
+++ b/src/modules/tests/tests/transfer/transfer-tez.ts
@@ -17,7 +17,7 @@ const send = async (to: string, amount: number) => {
       throw new Error("Invalid recipient address or amount");
     }
 
-    diagramStore.setProgress("estimate-fees", "running");
+    diagramStore.setProgress("estimate-fees");
     estimate = await Tezos.estimate.transfer({ to, amount: amount });
 
     if (estimate) {
@@ -28,12 +28,12 @@ const send = async (to: string, amount: number) => {
       });
     }
 
-    diagramStore.setProgress("wait-for-user", "running");
+    diagramStore.setProgress("wait-for-user");
     const transfer: TransactionWalletOperation = await Tezos.wallet
       .transfer({ to, amount })
       .send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running");
+    diagramStore.setProgress("wait-for-chain-confirmation");
     const confirmation = await transfer.confirmation();
 
     const opHash = getOperationHash(confirmation);

--- a/src/modules/tests/tests/transfer/transfer-tez.ts
+++ b/src/modules/tests/tests/transfer/transfer-tez.ts
@@ -4,8 +4,6 @@ import { useWalletStore } from "@/stores/walletStore";
 import type { Estimate, TransactionWalletOperation } from "@taquito/taquito";
 import { PiggyBank } from "lucide-vue-next";
 
-const TEST_ID = "transfer";
-
 let estimate: Estimate;
 const send = async (to: string, amount: number) => {
   const diagramStore = useDiagramStore();
@@ -19,7 +17,7 @@ const send = async (to: string, amount: number) => {
       throw new Error("Invalid recipient address or amount");
     }
 
-    diagramStore.setProgress("estimate-fees", "running", TEST_ID);
+    diagramStore.setProgress("estimate-fees", "running");
     estimate = await Tezos.estimate.transfer({ to, amount: amount });
 
     if (estimate) {
@@ -30,20 +28,20 @@ const send = async (to: string, amount: number) => {
       });
     }
 
-    diagramStore.setProgress("wait-for-user", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-user", "running");
     const transfer: TransactionWalletOperation = await Tezos.wallet
       .transfer({ to, amount })
       .send();
 
-    diagramStore.setProgress("wait-for-chain-confirmation", "running", TEST_ID);
+    diagramStore.setProgress("wait-for-chain-confirmation", "running");
     const confirmation = await transfer.confirmation();
 
     const opHash = getOperationHash(confirmation);
-    diagramStore.setOperationHash(opHash, TEST_ID);
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setOperationHash(opHash);
+    diagramStore.setCompleted();
   } catch (error) {
     console.error(`Failed to send transfer to '${to}': ${error}`);
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 

--- a/src/modules/tests/tests/transfer/transfer-tez.ts
+++ b/src/modules/tests/tests/transfer/transfer-tez.ts
@@ -40,7 +40,7 @@ const send = async (to: string, amount: number) => {
 
     const opHash = getOperationHash(confirmation);
     diagramStore.setOperationHash(opHash, TEST_ID);
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
   } catch (error) {
     console.error(`Failed to send transfer to '${to}': ${error}`);
     diagramStore.setErrorMessage(error, TEST_ID);

--- a/src/modules/tests/tests/tzip16-metadata/tzip16-metadata.ts
+++ b/src/modules/tests/tests/tzip16-metadata/tzip16-metadata.ts
@@ -45,11 +45,11 @@ const getContractMetadata = async (
   try {
     const Tezos = walletStore.getTezos;
 
-    diagramStore.setProgress("get-contract", "running");
+    diagramStore.setProgress("get-contract");
 
     const contract = await Tezos.wallet.at(contractAddress, tzip16);
 
-    diagramStore.setProgress("retrieve-metadata", "running");
+    diagramStore.setProgress("retrieve-metadata");
     const metadata = (await contract.tzip16().getMetadata()).metadata;
 
     diagramStore.setCompleted();
@@ -86,7 +86,7 @@ const executeMetadataView = async (
   diagramStore.setTestDiagram(TEST_ID, "execute-view");
 
   try {
-    diagramStore.setProgress("setup-contract", "running");
+    diagramStore.setProgress("setup-contract");
 
     // Get Tezos instance
     const Tezos = walletStore.getTezos;
@@ -94,7 +94,7 @@ const executeMetadataView = async (
     // Get contract instance
     const contract = await Tezos.contract.at(contractAddress);
 
-    diagramStore.setProgress("execute-view", "running");
+    diagramStore.setProgress("execute-view");
 
     // Execute the view
     // For views that take no parameters, use undefined or unit

--- a/src/modules/tests/tests/tzip16-metadata/tzip16-metadata.ts
+++ b/src/modules/tests/tests/tzip16-metadata/tzip16-metadata.ts
@@ -45,14 +45,14 @@ const getContractMetadata = async (
   try {
     const Tezos = walletStore.getTezos;
 
-    diagramStore.setProgress("get-contract", "running", TEST_ID);
+    diagramStore.setProgress("get-contract", "running");
 
     const contract = await Tezos.wallet.at(contractAddress, tzip16);
 
-    diagramStore.setProgress("retrieve-metadata", "running", TEST_ID);
+    diagramStore.setProgress("retrieve-metadata", "running");
     const metadata = (await contract.tzip16().getMetadata()).metadata;
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
 
     return {
       metadata: metadata as ContractMetadata,
@@ -61,7 +61,7 @@ const getContractMetadata = async (
     console.error(
       `Error retrieving metadata: ${JSON.stringify(error, null, 2)}`,
     );
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
   }
 };
 
@@ -86,7 +86,7 @@ const executeMetadataView = async (
   diagramStore.setTestDiagram(TEST_ID, "execute-view");
 
   try {
-    diagramStore.setProgress("setup-contract", "running", TEST_ID);
+    diagramStore.setProgress("setup-contract", "running");
 
     // Get Tezos instance
     const Tezos = walletStore.getTezos;
@@ -94,7 +94,7 @@ const executeMetadataView = async (
     // Get contract instance
     const contract = await Tezos.contract.at(contractAddress);
 
-    diagramStore.setProgress("execute-view", "running", TEST_ID);
+    diagramStore.setProgress("execute-view", "running");
 
     // Execute the view
     // For views that take no parameters, use undefined or unit
@@ -114,7 +114,7 @@ const executeMetadataView = async (
       viewCaller: walletAddress,
     });
 
-    diagramStore.setCompleted(TEST_ID);
+    diagramStore.setCompleted();
 
     return {
       viewName,
@@ -125,7 +125,7 @@ const executeMetadataView = async (
     console.error(
       `Error executing view '${viewName}': ${JSON.stringify(error, null, 2)}`,
     );
-    diagramStore.setErrorMessage(error, TEST_ID);
+    diagramStore.setErrorMessage(error);
     throw error;
   }
 };

--- a/src/modules/tests/tests/tzip16-metadata/tzip16-metadata.ts
+++ b/src/modules/tests/tests/tzip16-metadata/tzip16-metadata.ts
@@ -52,7 +52,7 @@ const getContractMetadata = async (
     diagramStore.setProgress("retrieve-metadata", "running", TEST_ID);
     const metadata = (await contract.tzip16().getMetadata()).metadata;
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
 
     return {
       metadata: metadata as ContractMetadata,
@@ -114,7 +114,7 @@ const executeMetadataView = async (
       viewCaller: walletAddress,
     });
 
-    diagramStore.setProgress("success", "completed", TEST_ID);
+    diagramStore.setCompleted(TEST_ID);
 
     return {
       viewName,

--- a/src/stores/diagramStore.ts
+++ b/src/stores/diagramStore.ts
@@ -70,9 +70,8 @@ export const useDiagramStore = defineStore("diagram", () => {
   const setProgress = async (
     stepId: string,
     status: "running" | "completed",
-    testId?: string,
   ) => {
-    if (testId && currentTestId.value !== testId) return;
+    if (!currentTestId.value) return;
 
     // Reset diagram if there was an error - this allows users to retry
     // and should only run when the user interacts with something, since
@@ -102,13 +101,9 @@ export const useDiagramStore = defineStore("diagram", () => {
     }
   };
 
-  /**
-   * Helper function to mark the current test as completed
-   *
-   * @param testId - The test ID to mark as completed
-   */
-  const setCompleted = async (testId?: string) => {
-    if (testId && currentTestId.value !== testId) return;
+  /** Helper function to mark the current test as completed */
+  const setCompleted = async () => {
+    if (!currentTestId.value) return;
 
     // Mark the current step as completed (timing-wise) if it exists
     if (currentStep.value && currentStep.value !== "success") {
@@ -129,8 +124,8 @@ export const useDiagramStore = defineStore("diagram", () => {
     await useWalletStore().fetchBalance();
   };
 
-  const setErrorMessage = (error: unknown, testId?: string) => {
-    if (testId && currentTestId.value !== testId) {
+  const setErrorMessage = (error: unknown) => {
+    if (!currentTestId.value) {
       return;
     }
 
@@ -147,8 +142,8 @@ export const useDiagramStore = defineStore("diagram", () => {
     diagramStatus.value = "errored";
   };
 
-  const setOperationHash = (hash: string | number, testId?: string) => {
-    if (testId && currentTestId.value !== testId) {
+  const setOperationHash = (hash: string | number) => {
+    if (!currentTestId.value) {
       return;
     }
     operationHash.value = hash;

--- a/src/stores/diagramStore.ts
+++ b/src/stores/diagramStore.ts
@@ -67,10 +67,7 @@ export const useDiagramStore = defineStore("diagram", () => {
     }
   };
 
-  const setProgress = async (
-    stepId: string,
-    status: "running" | "completed",
-  ) => {
+  const setProgress = async (stepId: string) => {
     if (!currentTestId.value) return;
 
     // Reset diagram if there was an error - this allows users to retry
@@ -79,7 +76,7 @@ export const useDiagramStore = defineStore("diagram", () => {
     if (errorMessage.value) {
       errorMessage.value = undefined;
       currentStep.value = stepId;
-      diagramStatus.value = status;
+      diagramStatus.value = "running";
     }
 
     if (currentDiagram.value && currentTestId.value) {
@@ -93,11 +90,7 @@ export const useDiagramStore = defineStore("diagram", () => {
       stepTimings.value.set(stepId, { startTime: performance.now() });
 
       currentStep.value = stepId;
-      diagramStatus.value = status;
-
-      if (status === "completed") {
-        await useWalletStore().fetchBalance();
-      }
+      diagramStatus.value = "running";
     }
   };
 

--- a/src/stores/diagramStore.ts
+++ b/src/stores/diagramStore.ts
@@ -102,6 +102,33 @@ export const useDiagramStore = defineStore("diagram", () => {
     }
   };
 
+  /**
+   * Helper function to mark the current test as completed
+   *
+   * @param testId - The test ID to mark as completed
+   */
+  const setCompleted = async (testId?: string) => {
+    if (testId && currentTestId.value !== testId) return;
+
+    // Mark the current step as completed (timing-wise) if it exists
+    if (currentStep.value && currentStep.value !== "success") {
+      const timing = stepTimings.value.get(currentStep.value);
+      if (timing?.startTime && !timing.endTime) {
+        timing.endTime = performance.now();
+        timing.duration = timing.endTime - timing.startTime;
+      }
+    }
+
+    // Set current step to "success" to highlight the success node in the diagram
+    stepTimings.value.set("success", { startTime: performance.now() });
+    currentStep.value = "success";
+
+    // Set diagram status to completed
+    diagramStatus.value = "completed";
+
+    await useWalletStore().fetchBalance();
+  };
+
   const setErrorMessage = (error: unknown, testId?: string) => {
     if (testId && currentTestId.value !== testId) {
       return;
@@ -286,6 +313,7 @@ export const useDiagramStore = defineStore("diagram", () => {
     setDiagram,
     setTestDiagram,
     setProgress,
+    setCompleted,
     resetDiagram,
     setErrorMessage,
     setOperationHash,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -9,12 +9,12 @@ export const connectToWallet = async ({ page }: { page: Page }) => {
   // Connect wallet
   await page.getByRole("button", { name: "Connect Wallet" }).click();
   await page.getByRole("combobox").click();
-  await page.getByRole("option", { name: "Programmatic (Testing)" }).click();
+  await page.getByRole("option", { name: "Raw Private Key Access" }).click();
   const privateKey = process.env.TEST_WALLET_PRIVATE_KEY;
   if (!privateKey) {
     throw new Error("TEST_WALLET_PRIVATE_KEY is not set");
   }
-  await page.getByPlaceholder("Private Key").fill(privateKey);
+  await page.getByPlaceholder("edsk...").fill(privateKey);
   await page.getByRole("button", { name: "Connect" }).click();
   await page.waitForSelector("text=Wallet connected");
 };


### PR DESCRIPTION
Closes #73

This pull request refactors the usage of the `diagramStore` in all test modules to simplify the API and remove the dependency on passing a `TEST_ID` to each method. The main benefits are cleaner, less error-prone code and easier onboarding for new contributors.

**Diagram store API simplification (most important):**
* All calls to `diagramStore` methods such as `setProgress`, `setOperationHash`, `setCompleted`, and `setErrorMessage` have been refactored to remove the `TEST_ID` parameter, making the API simpler and more consistent across all test modules. [[1]](diffhunk://#diff-f9a7ffb2fa49e4609c722168c81b8ef7233b7c72365ed38453e866901f520233L26-R45) [[2]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL43-R46) [[3]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL60-R74) [[4]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL94-R94) [[5]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL117-R117) [[6]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL131-R145) [[7]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL169-R177) [[8]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL191-R205) [[9]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL226-R229) [[10]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL243-R257) [[11]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL279-R291) [[12]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL315-R327) [[13]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL346-R353) [[14]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL373-R377) [[15]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L39-R44) [[16]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L58-R71) [[17]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L98-R101) [[18]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L115-R125) [[19]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L144-R147) [[20]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L161-R170)

**Documentation and onboarding improvements:**
* Updated comments and documentation in `CONTRIBUTING.md` to instruct contributors to set a default diagram in the Vue component's `onMounted` hook, and provided example code for this pattern. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R144) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R202-R205)

**Test completion and error handling:**
* Replaced calls to `setProgress("success", "completed", TEST_ID)` with the new `setCompleted()` method, and similarly refactored error handling to use the simplified API. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L159-R160) [[2]](diffhunk://#diff-f9a7ffb2fa49e4609c722168c81b8ef7233b7c72365ed38453e866901f520233L26-R45) [[3]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL60-R74) [[4]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL131-R145) [[5]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL191-R205) [[6]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL243-R257) [[7]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL279-R291) [[8]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL315-R327) [[9]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL346-R353) [[10]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL373-R377) [[11]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L58-R71) [[12]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L115-R125) [[13]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L161-R170)

**Consistent progress reporting:**
* Standardized progress reporting by removing status arguments (like `"running"`) from all `diagramStore.setProgress` calls, relying on the method's default behavior. [[1]](diffhunk://#diff-f9a7ffb2fa49e4609c722168c81b8ef7233b7c72365ed38453e866901f520233L26-R45) [[2]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL43-R46) [[3]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL60-R74) [[4]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL94-R94) [[5]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL117-R117) [[6]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL131-R145) [[7]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL169-R177) [[8]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL191-R205) [[9]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL226-R229) [[10]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL243-R257) [[11]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL279-R291) [[12]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL315-R327) [[13]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL346-R353) [[14]](diffhunk://#diff-9dedd0892f70f117c5f54db8829122ef17893925c3309187a095fbced88d2a4aL373-R377) [[15]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L39-R44) [[16]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L58-R71) [[17]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L98-R101) [[18]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L115-R125) [[19]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L144-R147) [[20]](diffhunk://#diff-0ff6372b901fc2b54e0505536c5c77cbe9aa944860296e35b12b3e34cfc19044L161-R170)