### PR TITLE
chore: remove dead/problematic testnet deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: taquito dapp pages deploy
 on:
   push:
     tags:
-      - '*'
+      - "*"
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -28,10 +28,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - environment: tallinnnet
-            project_name: taquito-dapp-tallinnnet
-          - environment: ghostnet
-            project_name: taquito-dapp-ghostnet
           - environment: shadownet
             project_name: taquito-dapp-shadownet
           - environment: tezlink-shadownet
@@ -61,7 +57,7 @@ jobs:
           node-version: 22.18.0
       - run: npx -y npm@11 ci
       - run: npm run format:check
-      
+
       # Debug environment variables
       - name: Debug Environment Variables
         run: |
@@ -69,18 +65,18 @@ jobs:
           echo "RPC_URL: ${{ vars.RPC_URL }}"
           echo "ALICE_WALLET_ADDRESS: ${{ vars.ALICE_WALLET_ADDRESS }}"
           echo "REOWN_PROJECT_ID: ${{ secrets.REOWN_PROJECT_ID }}"
-      
+
       - name: Fund wallet
         if: ${{ vars.DISABLE_WALLET_FUNDING != 'true' }}
         run: npm run fund-wallet ${{ vars.ALICE_WALLET_ADDRESS }}
-      
+
       # Install LIGO for contract compilation
       - name: Install LIGO
         run: |
           sudo systemctl start docker || true
           curl -sSL https://gitlab.com/ligolang/ligo/-/raw/dev/scripts/installer.sh | bash -s 1.10.0
           echo "$HOME/.ligo/bin" >> $GITHUB_PATH
-      
+
       - run: npm run compile-contracts
       - name: Originate contracts
         if: ${{ vars.DISABLE_ORIGINATION != 'true' }}

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -12,31 +12,30 @@ jobs:
     strategy:
       matrix:
         include:
-          - environment: seoulnet
-          - environment: ghostnet
+          - environment: shadownet
     env:
       VITE_NETWORK_TYPE: ${{ matrix.environment }}
       VITE_RPC_URL: ${{ vars.RPC_URL }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: lts/*
-    - name: Install dependencies
-      run: npx -y npm@11 ci
-    - name: Originate Counter Contract
-      run: npm run originate ${{ secrets.WALLET_PRIVATE_KEY }}
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
-    - name: Run Playwright tests
-      run: npx playwright test staking.spec.ts
-    - uses: actions/upload-artifact@v4
-      if: ${{ !cancelled() }}
-      with:
-        name: playwright-artifacts
-        path: |
-          playwright-report/
-          test-results/
-          test-results/**/*.zip
-          test-results/**/*.webm
-        retention-days: 15
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npx -y npm@11 ci
+      - name: Originate Counter Contract
+        run: npm run originate ${{ secrets.WALLET_PRIVATE_KEY }}
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npx playwright test staking.spec.ts
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-artifacts
+          path: |
+            playwright-report/
+            test-results/
+            test-results/**/*.zip
+            test-results/**/*.webm
+          retention-days: 15

--- a/README.md
+++ b/README.md
@@ -21,10 +21,7 @@ We consider this a **public good**. Our goal is to have a deployment ready on ev
 | Network               | URL                                        | Description                                      |
 | --------------------- | ------------------------------------------ | ------------------------------------------------ |
 | **Shadownet**         | https://shadownet.dapp.taquito.io/         | Long lived testnet                               |
-| **Ghostnet**          | https://ghostnet.dapp.taquito.io/          | Long lived testnet (will retire in ~March 2026)  |
 | **Tezlink Shadownet** | https://tezlink-shadownet.dapp.taquito.io/ | Tezos X Michelson Runtime connected to Shadownet |
-| **Seoulnet**          | https://seoulnet.dapp.taquito.io/          | Protocol 023 (PtSeouLo)                          |
-| **Tallinnnet**        | https://tallinnnet.dapp.taquito.io/        | Protocol 024 (PtTALLiN)                          |
 
 ## ✨ Available Tests
 

--- a/src/cloudflare/faucet/DEPLOYMENT.md
+++ b/src/cloudflare/faucet/DEPLOYMENT.md
@@ -57,9 +57,9 @@ Update `wrangler.jsonc` with production values:
 ```jsonc
 {
   "vars": {
-    "ALLOWED_ORIGINS": "ghostnet.dapp.taquito.io,seoulnet.dapp.taquito.io,shadownet.dapp.taquito.io",
-    "RPC_URL": "https://ghostnet.tezos.ecadinfra.com", // Default if user doesn't provide an RPC URL
-    "ALLOWED_RPC_URLS": "https://ghostnet.tezos.ecadinfra.com,https://shadownet.tezos.ecadinfra.com,https://seoulnet.tezos.ecadinfra.com",
+    "ALLOWED_ORIGINS": "shadownet.dapp.taquito.io",
+    "RPC_URL": "https://shadownet.tezos.ecadinfra.com", // Default if user doesn't provide an RPC URL
+    "ALLOWED_RPC_URLS": "https://shadownet.tezos.ecadinfra.com",
     "MIN_TEZ": "1",
     "MAX_TEZ": "10",
     "RATE_LIMIT_ENABLED": "true",

--- a/src/cloudflare/faucet/USAGE.md
+++ b/src/cloudflare/faucet/USAGE.md
@@ -49,7 +49,7 @@ const response = await fetch("/fund", {
     address: "tz1...",
     amount: 5,
     captchaToken: "turnstile_token",
-    rpc: "https://ghostnet.tezos.ecadinfra.com", // optional
+    rpc: "https://shadownet.tezos.ecadinfra.com", // optional
   }),
 });
 
@@ -59,6 +59,4 @@ console.log("Transaction:", result.txHash);
 
 ## Supported Networks
 
-- **Ghostnet**: `https://ghostnet.tezos.ecadinfra.com`
 - **Shadownet**: `https://shadownet.tezos.ecadinfra.com`
-- **Seoulnet**: `https://seoulnet.tezos.ecadinfra.com`

--- a/src/cloudflare/faucet/wrangler.jsonc
+++ b/src/cloudflare/faucet/wrangler.jsonc
@@ -24,8 +24,8 @@
 
   "vars": {
     // Secret keys are stored in the Cloudflare Secrets Manager (npx wrangler secret put)
-    "RPC_URL": "https://ghostnet.tezos.ecadinfra.com",
-    "ALLOWED_RPC_URLS": "https://ghostnet.tezos.ecadinfra.com,https://shadownet.tezos.ecadinfra.com,https://seoulnet.tezos.ecadinfra.com,https://rpc.shadownet.tezlink.nomadic-labs.com",
+    "RPC_URL": "https://shadownet.tezos.ecadinfra.com",
+    "ALLOWED_RPC_URLS": "https://shadownet.tezos.ecadinfra.com,https://rpc.shadownet.tezlink.nomadic-labs.com",
     "MIN_TEZ": "1",
     "MAX_TEZ": "10",
     "RATE_LIMIT_ENABLED": "true",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -30,12 +30,7 @@ export const buildIndexerUrl = (
     }
     return identifier ? `${baseUrl}/${identifier}/storage` : baseUrl;
   } else if (indexer.value === "tzstats") {
-    let prefix = "";
-    if (networkType === "ghostnet") {
-      prefix = "ghost.";
-    }
-
-    const baseUrl = indexer.url.replace("[networkType]", prefix);
+    const baseUrl = indexer.url.replace("[networkType]", "");
     if (routeType === "operations") {
       return identifier ? `${baseUrl}/${identifier}/operations` : baseUrl;
     }

--- a/src/modules/home/views/HomeView.vue
+++ b/src/modules/home/views/HomeView.vue
@@ -46,7 +46,7 @@
           <RouterLink :to="{ name: 'tests', params: { test: 'transfer' } }">
             <Button
               size="lg"
-              class="group bg-brand hover:bg-brand/90 hover:shadow-brand/25 px-8 transition-all duration-200 hover:scale-105 hover:shadow-lg"
+              class="bg-brand hover:bg-brand/90 hover:shadow-brand/25 group px-8 transition-all duration-200 hover:scale-105 hover:shadow-lg"
             >
               <span
                 class="transition-transform duration-200 group-hover:translate-x-1"
@@ -86,7 +86,7 @@
         >
           <div
             ref="statsSection"
-            class="group animate-on-scroll space-y-2"
+            class="animate-on-scroll group space-y-2"
             data-delay="0"
           >
             <div
@@ -100,7 +100,7 @@
               Interactive Tests
             </div>
           </div>
-          <div class="group animate-on-scroll space-y-2" data-delay="100">
+          <div class="animate-on-scroll group space-y-2" data-delay="100">
             <div
               class="text-brand text-3xl font-bold transition-transform duration-200 group-hover:scale-110"
             >
@@ -112,7 +112,7 @@
               Supported Networks
             </div>
           </div>
-          <div class="group animate-on-scroll space-y-2" data-delay="200">
+          <div class="animate-on-scroll group space-y-2" data-delay="200">
             <div
               class="text-brand text-3xl font-bold transition-transform duration-200 group-hover:scale-110"
             >
@@ -132,10 +132,10 @@
     <section id="features" class="relative overflow-hidden px-4 py-16">
       <!-- Background decorations -->
       <div
-        class="bg-brand/5 absolute top-0 left-1/4 h-96 w-96 rounded-full blur-3xl"
+        class="bg-brand/5 absolute left-1/4 top-0 h-96 w-96 rounded-full blur-3xl"
       ></div>
       <div
-        class="absolute right-1/4 bottom-0 h-96 w-96 rounded-full bg-blue-500/5 blur-3xl"
+        class="absolute bottom-0 right-1/4 h-96 w-96 rounded-full bg-blue-500/5 blur-3xl"
       ></div>
 
       <div class="relative mx-auto max-w-6xl space-y-12">
@@ -151,7 +151,7 @@
           <div
             v-for="(category, index) in featuredCategories"
             :key="category.name"
-            class="group animate-on-scroll hover:border-brand/30 hover:shadow-brand/10 cursor-pointer rounded-lg border p-6 transition-all duration-300 hover:-translate-y-2 hover:shadow-xl"
+            class="animate-on-scroll hover:border-brand/30 hover:shadow-brand/10 group cursor-pointer rounded-lg border p-6 transition-all duration-300 hover:-translate-y-2 hover:shadow-xl"
             :data-delay="index * 50"
           >
             <div class="flex items-start space-x-4">
@@ -197,7 +197,7 @@
     <section class="bg-muted/30 relative overflow-hidden px-4 py-16">
       <!-- Floating shapes -->
       <div
-        class="animate-float bg-brand/10 absolute top-1/4 right-0 h-32 w-32 rounded-full blur-xl"
+        class="animate-float bg-brand/10 absolute right-0 top-1/4 h-32 w-32 rounded-full blur-xl"
       ></div>
       <div
         class="animate-float-delay absolute bottom-1/4 left-0 h-24 w-24 rounded-full bg-blue-500/10 blur-xl"
@@ -216,7 +216,7 @@
             v-for="(test, index) in quickStartTests"
             :key="test.id"
             :to="{ name: 'tests', params: { test: test.id } }"
-            class="group bg-background animate-on-scroll hover:border-brand/30 hover:shadow-brand/10 rounded-lg border p-6 transition-all duration-250 hover:-translate-y-1 hover:shadow-xl"
+            class="bg-background animate-on-scroll hover:border-brand/30 hover:shadow-brand/10 duration-250 group rounded-lg border p-6 transition-all hover:-translate-y-1 hover:shadow-xl"
             :data-delay="index * 50"
           >
             <div class="space-y-3">
@@ -260,7 +260,7 @@
           <div
             v-for="(contract, index) in originatedContracts"
             :key="contract.address"
-            class="group bg-background animate-on-scroll w-full max-w-sm rounded-lg border p-6 transition-all duration-250 hover:-translate-y-1 hover:border-purple-500/30 hover:shadow-xl hover:shadow-purple-500/10 md:w-[calc(50%-0.5rem)] lg:w-[calc(33.333%-0.667rem)]"
+            class="bg-background animate-on-scroll duration-250 group w-full max-w-sm rounded-lg border p-6 transition-all hover:-translate-y-1 hover:border-purple-500/30 hover:shadow-xl hover:shadow-purple-500/10 md:w-[calc(50%-0.5rem)] lg:w-[calc(33.333%-0.667rem)]"
             :data-delay="index * 50"
           >
             <div class="space-y-3">
@@ -323,7 +323,7 @@
             href="https://taquito.io/"
             target="_blank"
             rel="noopener noreferrer"
-            class="group animate-on-scroll rounded-lg border p-6 transition-all duration-250 hover:-translate-y-1 hover:border-blue-500/30 hover:shadow-xl hover:shadow-blue-500/10"
+            class="animate-on-scroll duration-250 group rounded-lg border p-6 transition-all hover:-translate-y-1 hover:border-blue-500/30 hover:shadow-xl hover:shadow-blue-500/10"
             data-delay="0"
           >
             <div class="flex items-start space-x-4">
@@ -358,7 +358,7 @@
             href="https://github.com/ecadlabs/taquito-test-dapp-vue"
             target="_blank"
             rel="noopener noreferrer"
-            class="group animate-on-scroll rounded-lg border p-6 transition-all duration-250 hover:-translate-y-1 hover:border-gray-500/30 hover:shadow-xl hover:shadow-gray-500/10"
+            class="animate-on-scroll duration-250 group rounded-lg border p-6 transition-all hover:-translate-y-1 hover:border-gray-500/30 hover:shadow-xl hover:shadow-gray-500/10"
             data-delay="100"
           >
             <div class="flex items-start space-x-4">
@@ -390,7 +390,7 @@
 
           <!-- Live Networks -->
           <div
-            class="group animate-on-scroll rounded-lg border p-6 transition-all duration-250 hover:-translate-y-1 hover:border-green-500/30 hover:shadow-xl hover:shadow-green-500/10"
+            class="animate-on-scroll duration-250 group rounded-lg border p-6 transition-all hover:-translate-y-1 hover:border-green-500/30 hover:shadow-xl hover:shadow-green-500/10"
             data-delay="200"
           >
             <div class="flex items-start space-x-4">
@@ -411,20 +411,6 @@
                   Test on real Tezos testnets
                 </p>
                 <div class="space-y-1 text-sm">
-                  <a
-                    href="https://ghostnet.dapp.taquito.io/"
-                    target="_blank"
-                    class="block text-green-500 transition-transform duration-200 hover:translate-x-1 hover:underline"
-                  >
-                    Ghostnet →
-                  </a>
-                  <a
-                    href="https://seoulnet.dapp.taquito.io/"
-                    target="_blank"
-                    class="block text-green-500 transition-transform duration-200 hover:translate-x-1 hover:underline"
-                  >
-                    Seoulnet →
-                  </a>
                   <a
                     href="https://shadownet.dapp.taquito.io/"
                     target="_blank"
@@ -447,10 +433,10 @@
       <!-- Animated background -->
       <div class="absolute inset-0">
         <div
-          class="from-brand/5 absolute top-0 left-0 h-full w-full animate-pulse bg-gradient-to-r via-transparent to-orange-500/5"
+          class="from-brand/5 absolute left-0 top-0 h-full w-full animate-pulse bg-gradient-to-r via-transparent to-orange-500/5"
         ></div>
         <div
-          class="animate-float bg-brand/10 absolute -top-24 -right-24 h-48 w-48 rounded-full blur-3xl"
+          class="animate-float bg-brand/10 absolute -right-24 -top-24 h-48 w-48 rounded-full blur-3xl"
         ></div>
         <div
           class="animate-float-delay absolute -bottom-24 -left-24 h-48 w-48 rounded-full bg-orange-500/10 blur-3xl"
@@ -469,7 +455,7 @@
           <RouterLink :to="{ name: 'tests', params: { test: 'transfer' } }">
             <Button
               size="lg"
-              class="group bg-brand hover:shadow-brand/25 px-8 transition-all duration-200 hover:scale-105 hover:bg-[#B8722A] hover:shadow-xl"
+              class="bg-brand hover:shadow-brand/25 group px-8 transition-all duration-200 hover:scale-105 hover:bg-[#B8722A] hover:shadow-xl"
             >
               <span
                 class="transition-transform duration-200 group-hover:translate-x-1"

--- a/src/modules/home/views/HomeView.vue
+++ b/src/modules/home/views/HomeView.vue
@@ -132,10 +132,10 @@
     <section id="features" class="relative overflow-hidden px-4 py-16">
       <!-- Background decorations -->
       <div
-        class="bg-brand/5 absolute left-1/4 top-0 h-96 w-96 rounded-full blur-3xl"
+        class="bg-brand/5 absolute top-0 left-1/4 h-96 w-96 rounded-full blur-3xl"
       ></div>
       <div
-        class="absolute bottom-0 right-1/4 h-96 w-96 rounded-full bg-blue-500/5 blur-3xl"
+        class="absolute right-1/4 bottom-0 h-96 w-96 rounded-full bg-blue-500/5 blur-3xl"
       ></div>
 
       <div class="relative mx-auto max-w-6xl space-y-12">
@@ -197,7 +197,7 @@
     <section class="bg-muted/30 relative overflow-hidden px-4 py-16">
       <!-- Floating shapes -->
       <div
-        class="animate-float bg-brand/10 absolute right-0 top-1/4 h-32 w-32 rounded-full blur-xl"
+        class="animate-float bg-brand/10 absolute top-1/4 right-0 h-32 w-32 rounded-full blur-xl"
       ></div>
       <div
         class="animate-float-delay absolute bottom-1/4 left-0 h-24 w-24 rounded-full bg-blue-500/10 blur-xl"
@@ -216,7 +216,7 @@
             v-for="(test, index) in quickStartTests"
             :key="test.id"
             :to="{ name: 'tests', params: { test: test.id } }"
-            class="bg-background animate-on-scroll hover:border-brand/30 hover:shadow-brand/10 duration-250 group rounded-lg border p-6 transition-all hover:-translate-y-1 hover:shadow-xl"
+            class="bg-background animate-on-scroll hover:border-brand/30 hover:shadow-brand/10 group rounded-lg border p-6 transition-all duration-250 hover:-translate-y-1 hover:shadow-xl"
             :data-delay="index * 50"
           >
             <div class="space-y-3">
@@ -260,7 +260,7 @@
           <div
             v-for="(contract, index) in originatedContracts"
             :key="contract.address"
-            class="bg-background animate-on-scroll duration-250 group w-full max-w-sm rounded-lg border p-6 transition-all hover:-translate-y-1 hover:border-purple-500/30 hover:shadow-xl hover:shadow-purple-500/10 md:w-[calc(50%-0.5rem)] lg:w-[calc(33.333%-0.667rem)]"
+            class="bg-background animate-on-scroll group w-full max-w-sm rounded-lg border p-6 transition-all duration-250 hover:-translate-y-1 hover:border-purple-500/30 hover:shadow-xl hover:shadow-purple-500/10 md:w-[calc(50%-0.5rem)] lg:w-[calc(33.333%-0.667rem)]"
             :data-delay="index * 50"
           >
             <div class="space-y-3">
@@ -323,7 +323,7 @@
             href="https://taquito.io/"
             target="_blank"
             rel="noopener noreferrer"
-            class="animate-on-scroll duration-250 group rounded-lg border p-6 transition-all hover:-translate-y-1 hover:border-blue-500/30 hover:shadow-xl hover:shadow-blue-500/10"
+            class="animate-on-scroll group rounded-lg border p-6 transition-all duration-250 hover:-translate-y-1 hover:border-blue-500/30 hover:shadow-xl hover:shadow-blue-500/10"
             data-delay="0"
           >
             <div class="flex items-start space-x-4">
@@ -358,7 +358,7 @@
             href="https://github.com/ecadlabs/taquito-test-dapp-vue"
             target="_blank"
             rel="noopener noreferrer"
-            class="animate-on-scroll duration-250 group rounded-lg border p-6 transition-all hover:-translate-y-1 hover:border-gray-500/30 hover:shadow-xl hover:shadow-gray-500/10"
+            class="animate-on-scroll group rounded-lg border p-6 transition-all duration-250 hover:-translate-y-1 hover:border-gray-500/30 hover:shadow-xl hover:shadow-gray-500/10"
             data-delay="100"
           >
             <div class="flex items-start space-x-4">
@@ -390,7 +390,7 @@
 
           <!-- Live Networks -->
           <div
-            class="animate-on-scroll duration-250 group rounded-lg border p-6 transition-all hover:-translate-y-1 hover:border-green-500/30 hover:shadow-xl hover:shadow-green-500/10"
+            class="animate-on-scroll group rounded-lg border p-6 transition-all duration-250 hover:-translate-y-1 hover:border-green-500/30 hover:shadow-xl hover:shadow-green-500/10"
             data-delay="200"
           >
             <div class="flex items-start space-x-4">
@@ -433,10 +433,10 @@
       <!-- Animated background -->
       <div class="absolute inset-0">
         <div
-          class="from-brand/5 absolute left-0 top-0 h-full w-full animate-pulse bg-gradient-to-r via-transparent to-orange-500/5"
+          class="from-brand/5 absolute top-0 left-0 h-full w-full animate-pulse bg-gradient-to-r via-transparent to-orange-500/5"
         ></div>
         <div
-          class="animate-float bg-brand/10 absolute -right-24 -top-24 h-48 w-48 rounded-full blur-3xl"
+          class="animate-float bg-brand/10 absolute -top-24 -right-24 h-48 w-48 rounded-full blur-3xl"
         ></div>
         <div
           class="animate-float-delay absolute -bottom-24 -left-24 h-48 w-48 rounded-full bg-orange-500/10 blur-3xl"

--- a/src/modules/tests/tests/etherlink-bridge/bridge-config.ts
+++ b/src/modules/tests/tests/etherlink-bridge/bridge-config.ts
@@ -14,10 +14,10 @@ export interface BridgeConfig {
 
 /** Bridge configuration by network */
 export const bridgeConfigs: Record<string, BridgeConfig> = {
-  ghostnet: {
-    bridgeContract: "KT1VEjeQfDBSfpDH5WeBM5LukHPGM2htYEh3",
-    exchangerContract: "KT1Bp9YUvUBJgXxf5UrYTM2CGRUPixURqx4m",
-    rollupAddress: "sr18wx6ezkeRjt1SZSeZ2UQzQN3Uc3YLMLqg",
+  shadownet: {
+    bridgeContract: "KT19aBsSWvWtvEkbiqReJnD8UzQMWcD8SHUD",
+    exchangerContract: "KT1JYZsawXmeArts18nn4uT79tUJc4AGTYgc",
+    rollupAddress: "sr1N9XzPi4bpFzaJGymynstqu8WqurCE9eQy",
   },
 };
 

--- a/src/modules/tests/tests/etherlink-bridge/etherlink-bridge.ts
+++ b/src/modules/tests/tests/etherlink-bridge/etherlink-bridge.ts
@@ -72,7 +72,7 @@ const depositToEtherlink = async (
 
   if (!bridgeConfig) {
     const error = new Error(
-      `Bridge not configured for network: ${networkType}. Currently only Ghostnet is supported.`,
+      `Bridge not configured for network: ${networkType}. Currently only Shadownet is supported.`,
     );
     diagramStore.setErrorMessage(error);
     throw error;

--- a/tests/viewing-blocks.spec.ts
+++ b/tests/viewing-blocks.spec.ts
@@ -2,7 +2,8 @@ import { test } from "@playwright/test";
 import { goToTest, waitForSuccess } from "./helpers.ts";
 import { getSharedPage, setupSharedContext } from "./shared-context.ts";
 
-const RPC_URL = process.env.VITE_RPC_URL || "https://ghostnet.ecadinfra.com";
+const RPC_URL =
+  process.env.VITE_RPC_URL || "https://rpc.shadownet.teztnets.com/";
 
 async function getRandomBlockInLast10000(): Promise<number> {
   const response = await fetch(`${RPC_URL}/chains/main/blocks/head/header`);


### PR DESCRIPTION
## Summary
- remove  and  from the stable deployment workflow
- remove stale  references from the README, homepage live-network links, and faucet defaults/docs
- switch the viewing-blocks test fallback RPC from  to 
- remove tallinnnet because it is harmful due to drift in protocol constants

## Verification
-  on the changed files

## Notes
- this PR intentionally leaves the Etherlink bridge's  config alone, since removing it would change feature support rather than just cleaning up dead deployment surfaces