### PR TITLE
Create Pages projects before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,16 @@ jobs:
           export NODE_OPTIONS="--max_old_space_size=4096"
           npm run build:verified
 
+      - name: Ensure Cloudflare Pages project exists
+        uses: cloudflare/wrangler-action@v3
+        continue-on-error: true
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          wranglerVersion: "4.83.0"
+          command: pages project create ${{ matrix.project_name }} --production-branch=main
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish to Cloudflare Pages
         id: cloudflare_publish
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## Summary
- add a pre-publish workflow step that creates the Cloudflare Pages project for each deploy matrix entry
- keep the create step non-fatal so existing projects continue through to the normal publish step

## Context
The `1.0.18` release deploy reached the Ushuaianet publish step and failed because `taquito-dapp-ushuaianet` did not exist in Cloudflare Pages. This lets the release workflow create missing Pages projects with the existing Cloudflare secrets before deploying.

## Validation
- `npm run format:check -- .github/workflows/deploy.yml`
- `git diff --check`
