### PR TITLE
Remove retired ECAD infra endpoint usage

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       VITE_NETWORK_TYPE: ${{ matrix.environment }}
       VITE_RPC_URL: ${{ vars.RPC_URL }}
+      WALLET_PRIVATE_KEY: ${{ secrets.WALLET_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ npm run build:verified # Build and fail if the target network is missing require
 npm run preview      # Preview production build
 npm run test         # Run Playwright tests
 npm run test:ui      # Run tests with UI
+npm run test:guardrails # Run configuration guardrails
 
 # Contract Management
 npm run originate    # Deploy contracts
@@ -124,6 +125,17 @@ projects named `taquito-dapp-<network>`. To deploy Ushuaianet, create or verify:
 The workflow compiles and originates the test contracts before
 `npm run build:verified`, so the first successful Ushuaianet deploy should
 write that network's fixture addresses into `src/networks/network-contracts.json`.
+
+### RPC and Test Wallets
+
+The dApp should not point at retired ECAD Infra RPC endpoints. Shadownet uses
+`https://rpc.shadownet.teztnets.com`, Ushuaianet uses
+`https://rpc.ushuaianet.teztnets.com`, and Tezlink Shadownet uses
+`https://rpc.shadownet.tezlink.nomadic-labs.com`.
+
+Playwright tests use `TEST_WALLET_PRIVATE_KEY` or `WALLET_PRIVATE_KEY` when
+provided. If a disposable key service is needed for local testing, set
+`TEST_KEYGEN_URL` explicitly; there is no built-in keygen host.
 
 ### Project Structure
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepare": "husky",
     "test": "npx playwright test",
     "test:ui": "npx playwright test --ui",
-    "test:guardrails": "node --import tsx --test src/modules/tests/readiness.test.ts"
+    "test:guardrails": "node --import tsx --test src/modules/tests/*.test.ts"
   },
   "dependencies": {
     "@ledgerhq/hw-transport-webhid": "^6.30.8",

--- a/src/modules/tests/endpoint-guardrails.test.ts
+++ b/src/modules/tests/endpoint-guardrails.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import test from "node:test";
+
+const retiredEndpointDomain = ["ecadinfra", "com"].join(".");
+const pathsToScan = [
+  ".env.example",
+  ".github",
+  "README.md",
+  "package.json",
+  "playwright.config.ts",
+  "public",
+  "src",
+  "tests",
+  "vite.config.ts",
+];
+const ignoredDirectories = new Set(["node_modules", "dist", "test-results"]);
+
+const collectFiles = async (path: string): Promise<string[]> => {
+  const entries = await readdir(path, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const childPath = join(path, entry.name);
+      if (entry.isDirectory()) {
+        if (ignoredDirectories.has(entry.name)) {
+          return [];
+        }
+        return collectFiles(childPath);
+      }
+      if (!entry.isFile()) {
+        return [];
+      }
+      return [childPath];
+    }),
+  );
+
+  return files.flat();
+};
+
+const collectPathFiles = async (path: string): Promise<string[]> => {
+  const pathStats = await stat(path);
+  if (pathStats.isDirectory()) {
+    return collectFiles(path);
+  }
+  if (pathStats.isFile()) {
+    return [path];
+  }
+  return [];
+};
+
+test("does not reference retired ECAD infra endpoints", async () => {
+  const files = (
+    await Promise.all(pathsToScan.map((path) => collectPathFiles(path)))
+  ).flat();
+
+  const matches: string[] = [];
+  await Promise.all(
+    files.map(async (file) => {
+      const contents = await readFile(file, "utf8");
+      if (contents.includes(retiredEndpointDomain)) {
+        matches.push(file);
+      }
+    }),
+  );
+
+  assert.deepEqual(matches.sort(), []);
+});

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -38,6 +38,27 @@ export type Settings = {
   themeMode: ThemeMode;
 };
 
+const activeRpcUrlByNetwork: Record<string, string> = {
+  shadownet: "https://rpc.shadownet.teztnets.com",
+  ushuaianet: "https://rpc.ushuaianet.teztnets.com",
+  "tezlink-shadownet": "https://rpc.shadownet.tezlink.nomadic-labs.com",
+};
+const retiredRpcDomain = ["ecadinfra", "com"].join(".");
+
+const isRetiredRpcUrl = (rpcUrl: string | undefined): boolean =>
+  rpcUrl?.includes(retiredRpcDomain) ?? false;
+
+const getDefaultRpcUrl = (): string => {
+  const configuredRpcUrl = import.meta.env.VITE_RPC_URL;
+  if (!isRetiredRpcUrl(configuredRpcUrl)) {
+    return configuredRpcUrl;
+  }
+
+  return (
+    activeRpcUrlByNetwork[import.meta.env.VITE_NETWORK_TYPE] ?? configuredRpcUrl
+  );
+};
+
 const defaultSettings: Settings = {
   indexer:
     availableIndexers.find((indexer) =>
@@ -45,21 +66,28 @@ const defaultSettings: Settings = {
         import.meta.env.VITE_NETWORK_TYPE as NetworkType,
       ),
     ) || availableIndexers[0],
-  rpcUrl: import.meta.env.VITE_RPC_URL,
+  rpcUrl: getDefaultRpcUrl(),
   confirmationCount: 3,
   themeMode: "light",
 };
 
 export const useSettingsStore = defineStore("settings", () => {
+  const migrateSettings = (settings: Settings): Settings => ({
+    ...settings,
+    rpcUrl: isRetiredRpcUrl(settings.rpcUrl)
+      ? defaultSettings.rpcUrl
+      : settings.rpcUrl,
+  });
+
   const getMergedSettings = (): Settings => {
     const stored = localStorage.getItem("playground-settings");
     if (!stored) return { ...defaultSettings };
     try {
       const parsed = JSON.parse(stored) as Partial<Settings>;
-      return {
+      return migrateSettings({
         ...defaultSettings,
         ...parsed,
-      };
+      });
     } catch {
       return { ...defaultSettings };
     }
@@ -72,7 +100,7 @@ export const useSettingsStore = defineStore("settings", () => {
   const getConfirmationCount = computed(() => settings.value.confirmationCount);
   const getThemeMode = computed(() => settings.value.themeMode);
   const isUsingCustomRpcUrl = computed(() => {
-    return settings.value.rpcUrl !== import.meta.env.VITE_RPC_URL;
+    return settings.value.rpcUrl !== defaultSettings.rpcUrl;
   });
 
   const setThemeMode = (themeMode: ThemeMode) => {
@@ -89,7 +117,7 @@ export const useSettingsStore = defineStore("settings", () => {
   );
 
   const resetRpcUrl = () => {
-    settings.value.rpcUrl = import.meta.env.VITE_RPC_URL;
+    settings.value.rpcUrl = defaultSettings.rpcUrl;
   };
 
   return {

--- a/tests/global.setup.ts
+++ b/tests/global.setup.ts
@@ -4,20 +4,39 @@ import dotenv from "dotenv";
 dotenv.config();
 
 setup("create new private key", async ({}) => {
+  const existingPrivateKey =
+    process.env.TEST_WALLET_PRIVATE_KEY ?? process.env.WALLET_PRIVATE_KEY;
+  if (existingPrivateKey) {
+    process.env.TEST_WALLET_PRIVATE_KEY = existingPrivateKey;
+    console.log(
+      `Using provided private key for ${process.env.VITE_NETWORK_TYPE}`,
+    );
+    return;
+  }
+
+  const keygenUrl = process.env.TEST_KEYGEN_URL;
+  if (!keygenUrl) {
+    throw new Error(
+      "Set TEST_WALLET_PRIVATE_KEY or WALLET_PRIVATE_KEY before running Playwright tests. TEST_KEYGEN_URL can be set when a disposable key service is available.",
+    );
+  }
+
   console.log(
-    `🔑 Creating new private key for ${process.env.VITE_NETWORK_TYPE}...`,
+    `Creating new private key for ${process.env.VITE_NETWORK_TYPE}...`,
   );
 
-  const response = await fetch(
-    `https://keygen.ecadinfra.com/${process.env.VITE_NETWORK_TYPE}`,
-    {
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        Authorization: "Bearer taquito-example",
-      },
-    },
+  const keyUrl = new URL(
+    process.env.VITE_NETWORK_TYPE ?? "",
+    keygenUrl.endsWith("/") ? keygenUrl : `${keygenUrl}/`,
   );
+
+  const response = await fetch(keyUrl, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      Authorization: "Bearer taquito-example",
+    },
+  });
 
   if (response.status !== 200) {
     console.error(`Failed to create private key: ${response.statusText}`);
@@ -28,6 +47,6 @@ setup("create new private key", async ({}) => {
 
   process.env.TEST_WALLET_PRIVATE_KEY = privateKey;
   console.log(
-    `🔐 Private key created and saved for ${process.env.VITE_NETWORK_TYPE}`,
+    `Private key created and saved for ${process.env.VITE_NETWORK_TYPE}`,
   );
 });


### PR DESCRIPTION
## Summary
- remove the hardcoded ECAD Infra keygen host from Playwright setup; tests now use TEST_WALLET_PRIVATE_KEY or WALLET_PRIVATE_KEY, with TEST_KEYGEN_URL as an explicit opt-in fallback
- migrate persisted settings away from retired ECAD Infra RPC URLs to the active network default, so old browser localStorage no longer keeps the settings CTA on the retired Shadownet RPC
- add a guardrail test to block retired ECAD Infra endpoint references in source, workflows, docs, and test files
- document the active Shadownet, Ushuaianet, and Tezlink Shadownet RPC URLs

## Verification
- npm run format:check -- .github/workflows/visual-tests.yml README.md package.json src/stores/settingsStore.ts src/modules/tests/endpoint-guardrails.test.ts tests/global.setup.ts
- npm run test:guardrails
- npm run lint
- npm run build
- git diff --check
- rg -n 'ecadinfra\.com|tezos\.ecadinfra\.com|keygen\.ecadinfra\.com' .github src tests README.md package.json package-lock.json public vite.config.ts playwright.config.ts .env.example || true
- rg -n 'ecadinfra\.com|tezos\.ecadinfra\.com|keygen\.ecadinfra\.com' dist || true